### PR TITLE
Add repo-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Node dependencies and build outputs
+**/node_modules/
+**/dist/
+**/dist-ssr/
+**/build/
+
+# Log files
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Local environment files
+*.local
+
+# SQLite databases generated at runtime
+*.sqlite
+
+# macOS and system files
+.DS_Store
+Thumbs.db
+
+# IDE and editor folders
+.vscode/
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Xcode user data and build products
+*.xcodeproj/**/xcuserdata/
+*.xcworkspace/**/xcuserdata/
+DerivedData/
+xcuserdata/


### PR DESCRIPTION
## Summary
- add a top level `.gitignore` to ignore node modules, log files, editor settings, and Xcode build artifacts

## Testing
- `npm test` in `cueit-backend` *(fails: npm cannot reach registry)*
- `npm test` in `cueit-admin` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865c2e363c0833382b245b5bd23817a