### PR TITLE
Add READMEs and admin UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # CueIT
 
-CueIT is an internal help desk application used to submit and track IT tickets.
+CueIT is an internal help desk application used to submit and track IT tickets. The repository contains three apps:
+
+- **cueit-backend** – Express/SQLite API
+- **cueit-admin** – React admin interface
+- **cueit-kiosk** – iPad kiosk for ticket submission
 
 ## Requirements
 - [Node.js](https://nodejs.org/) 18 or higher

--- a/cueit-admin/README.md
+++ b/cueit-admin/README.md
@@ -1,12 +1,10 @@
-# React + Vite
+# CueIT Admin
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React based interface for viewing help desk tickets and managing system settings.
 
-Currently, two official plugins are available:
+## Setup
+1. Run `npm install` in this directory.
+2. Create a `.env` file with `VITE_API_URL` and optional `VITE_LOGO_URL`.
+3. Start the dev server with `npm run dev`.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+The admin UI lets you search tickets, edit configuration values and activate kiosk devices.

--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useMemo } from 'react';
 import axios from 'axios';
 import Navbar from './Navbar';
+import ConfigPanel from './ConfigPanel';
+import KiosksPanel from './KiosksPanel';
 import './App.css';
 
 const urgencyPriority = { Urgent: 3, High: 2, Medium: 1, Low: 0 };
@@ -11,6 +13,8 @@ function App() {
   const [search, setSearch] = useState('');
   const [sortField, setSortField] = useState('timestamp');
   const [showSearch, setShowSearch] = useState(false);
+  const [showConfig, setShowConfig] = useState(false);
+  const [showKiosks, setShowKiosks] = useState(false);
   const [urgencyFilter, setUrgencyFilter] = useState('');
   const [systemFilter, setSystemFilter] = useState('');
 
@@ -67,27 +71,15 @@ function App() {
 
   return (
     <>
-      <Navbar logo={config.logoUrl} />
-      <div className="bg-blue-100 text-black py-2 flex justify-center">
-        <div className="relative">
-          <button
-            onClick={() => setShowSearch(!showSearch)}
-            className="text-gray-700 hover:text-black transition p-1"
-            aria-label="Toggle Search"
-          >
-            🔍
-          </button>
-          {showSearch && (
-            <input
-              type="text"
-              placeholder="Search..."
-              className="ml-2 w-56 px-4 py-1 border rounded-full text-sm shadow bg-white"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          )}
-        </div>
-      </div>
+      <Navbar
+        logo={config.logoUrl}
+        search={search}
+        setSearch={setSearch}
+        showSearch={showSearch}
+        setShowSearch={setShowSearch}
+        openConfig={() => setShowConfig(true)}
+        openKiosks={() => setShowKiosks(true)}
+      />
       <div className="min-h-screen bg-gray-900 text-white pb-8">
         <div className="max-w-7xl mx-auto">
           {loading ? (
@@ -179,53 +171,23 @@ function App() {
               </div>
             </div>
           )}
-          <div className="bg-gray-800 mt-10 p-6 rounded text-sm">
-            <h2 className="text-lg mb-4">Configuration</h2>
-            <div className="space-y-3">
-              <label className="block">
-                Logo URL
-                <input
-                  type="text"
-                  value={config.logoUrl || ''}
-                  onChange={(e) => setConfig({ ...config, logoUrl: e.target.value })}
-                  className="mt-1 w-full px-2 py-1 rounded text-black"
-                />
-              </label>
-              <label className="block">
-                Welcome Message
-                <input
-                  type="text"
-                  value={config.welcomeMessage || ''}
-                  onChange={(e) => setConfig({ ...config, welcomeMessage: e.target.value })}
-                  className="mt-1 w-full px-2 py-1 rounded text-black"
-                />
-              </label>
-              <label className="block">
-                Help Message
-                <input
-                  type="text"
-                  value={config.helpMessage || ''}
-                  onChange={(e) => setConfig({ ...config, helpMessage: e.target.value })}
-                  className="mt-1 w-full px-2 py-1 rounded text-black"
-                />
-              </label>
-              <button
-                onClick={async () => {
-                  try {
-                    await axios.put(`${import.meta.env.VITE_API_URL}/api/config`, config);
-                    alert('Saved');
-                  } catch (err) {
-                    alert('Failed');
-                  }
-                }}
-                className="px-4 py-2 bg-blue-600 text-white rounded mt-2"
-              >
-                Save
-              </button>
-            </div>
-          </div>
         </div>
       </div>
+      <ConfigPanel
+        open={showConfig}
+        onClose={() => setShowConfig(false)}
+        config={config}
+        setConfig={setConfig}
+        save={async () => {
+          try {
+            await axios.put(`${import.meta.env.VITE_API_URL}/api/config`, config);
+            alert('Saved');
+          } catch {
+            alert('Failed');
+          }
+        }}
+      />
+      <KiosksPanel open={showKiosks} onClose={() => setShowKiosks(false)} />
     </>
   );
 }

--- a/cueit-admin/src/ConfigPanel.jsx
+++ b/cueit-admin/src/ConfigPanel.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export default function ConfigPanel({ open, onClose, config, setConfig, save }) {
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 z-40 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+    >
+      <div
+        className={`absolute right-0 top-0 bottom-0 w-80 bg-gray-800 text-white p-6 transform transition-transform duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <button onClick={onClose} className="mb-4 text-right w-full hover:text-gray-300">
+          ✖
+        </button>
+        <h2 className="text-lg mb-4">Configuration</h2>
+        <div className="space-y-3 text-sm">
+          <label className="block">
+            Logo URL
+            <input
+              type="text"
+              value={config.logoUrl || ''}
+              onChange={(e) => setConfig({ ...config, logoUrl: e.target.value })}
+              className="mt-1 w-full px-2 py-1 rounded text-black"
+            />
+          </label>
+          <label className="block">
+            Welcome Message
+            <input
+              type="text"
+              value={config.welcomeMessage || ''}
+              onChange={(e) => setConfig({ ...config, welcomeMessage: e.target.value })}
+              className="mt-1 w-full px-2 py-1 rounded text-black"
+            />
+          </label>
+          <label className="block">
+            Help Message
+            <input
+              type="text"
+              value={config.helpMessage || ''}
+              onChange={(e) => setConfig({ ...config, helpMessage: e.target.value })}
+              className="mt-1 w-full px-2 py-1 rounded text-black"
+            />
+          </label>
+          <button onClick={save} className="px-4 py-2 bg-blue-600 text-white rounded mt-2">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cueit-admin/src/KiosksPanel.jsx
+++ b/cueit-admin/src/KiosksPanel.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export default function KiosksPanel({ open, onClose }) {
+  const [kiosks, setKiosks] = useState([]);
+  const api = import.meta.env.VITE_API_URL;
+
+  useEffect(() => {
+    if (open) {
+      axios.get(`${api}/api/kiosks`).then((res) => setKiosks(res.data));
+    }
+  }, [open, api]);
+
+  const toggle = async (id, active) => {
+    await axios.put(`${api}/api/kiosks/${id}/active`, { active: !active });
+    setKiosks((k) => k.map((x) => (x.id === id ? { ...x, active: !active } : x)));
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black/50 z-40 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+    >
+      <div
+        className={`absolute right-0 top-0 bottom-0 w-96 bg-gray-800 text-white p-6 transform transition-transform duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <button onClick={onClose} className="mb-4 text-right w-full hover:text-gray-300">
+          ✖
+        </button>
+        <h2 className="text-lg mb-4">Kiosks</h2>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="pb-2">ID</th>
+              <th className="pb-2">Version</th>
+              <th className="pb-2">Last Seen</th>
+              <th className="pb-2">Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {kiosks.map((k) => (
+              <tr key={k.id} className="border-t border-gray-700">
+                <td className="py-1 pr-2 font-mono break-all">{k.id}</td>
+                <td className="py-1 pr-2">{k.version}</td>
+                <td className="py-1 pr-2 text-xs">{new Date(k.last_seen).toLocaleString()}</td>
+                <td className="py-1">
+                  <button
+                    onClick={() => toggle(k.id, k.active)}
+                    className={`px-2 py-1 rounded text-xs ${k.active ? 'bg-green-600' : 'bg-red-600'}`}
+                  >
+                    {k.active ? 'Disable' : 'Activate'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -1,14 +1,40 @@
 import React from 'react';
 
-export default function Navbar({ logo }) {
+export default function Navbar({
+  logo,
+  search,
+  setSearch,
+  showSearch,
+  setShowSearch,
+  openConfig,
+  openKiosks,
+}) {
   return (
-    <nav className="bg-blue-600 text-white shadow-md border-b border-blue-700 sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between relative">
-        <div className="flex items-center gap-5">
-          {logo && (
-            <img src={logo} alt="Logo" className="h-[50px] w-[50px] object-contain" />
-          )}
-          <h1 className="text-xl font-semibold tracking-tight">CueIT Admin</h1>
+    <nav className="bg-blue-600 text-white shadow-md sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-6 py-2 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {logo && <img src={logo} alt="Logo" className="h-8 w-8 object-contain" />}
+          <h1 className="text-lg font-semibold tracking-tight">CueIT Admin</h1>
+        </div>
+        <div className="flex items-center gap-4">
+          <button onClick={openKiosks} className="hover:text-gray-200 text-sm">Kiosks</button>
+          <button onClick={openConfig} className="hover:text-gray-200 text-sm">Config</button>
+          <div className="relative">
+            <button
+              onClick={() => setShowSearch(!showSearch)}
+              className="p-1 hover:text-gray-200"
+              aria-label="Toggle Search"
+            >
+              🔍
+            </button>
+            <input
+              type="text"
+              placeholder="Search..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className={`absolute right-0 top-1/2 -translate-y-1/2 bg-white text-black px-4 py-1 rounded-full w-56 transition-all duration-300 shadow ${showSearch ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-full'}`}
+            />
+          </div>
         </div>
       </div>
     </nav>

--- a/cueit-backend/README.md
+++ b/cueit-backend/README.md
@@ -1,0 +1,11 @@
+# CueIT Backend
+
+An Express and SQLite API that receives help desk tickets and stores configuration.
+
+## Setup
+1. Run `npm install` in this folder.
+2. Create a `.env` file with your SMTP details and set `HELPDESK_EMAIL`.
+   Optional variables are `API_PORT` and `LOGO_URL`.
+3. Start the server with `node index.js`.
+
+Kiosk devices register with `/api/register-kiosk` and can be activated through the admin UI.

--- a/cueit-backend/db.js
+++ b/cueit-backend/db.js
@@ -28,9 +28,13 @@ db.serialize(() => {
     CREATE TABLE IF NOT EXISTS kiosks (
       id TEXT PRIMARY KEY,
       last_seen TEXT,
-      version TEXT
+      version TEXT,
+      active INTEGER DEFAULT 0
     )
   `);
+
+  // add active column if database was created with an older schema
+  db.run(`ALTER TABLE kiosks ADD COLUMN active INTEGER DEFAULT 0`, () => {});
 
   // insert default config if not present
   const defaults = {

--- a/cueit-backend/index.js
+++ b/cueit-backend/index.js
@@ -123,6 +123,19 @@ app.get("/api/kiosks", (req, res) => {
   });
 });
 
+app.put("/api/kiosks/:id/active", (req, res) => {
+  const { id } = req.params;
+  const { active } = req.body;
+  db.run(
+    `UPDATE kiosks SET active=? WHERE id=?`,
+    [active ? 1 : 0, id],
+    (err) => {
+      if (err) return res.status(500).json({ error: "DB error" });
+      res.json({ message: "updated" });
+    }
+  );
+});
+
 app.listen(PORT, () => {
   console.log(`✅ CueIT Backend running at http://localhost:${PORT}`);
 });

--- a/cueit-kiosk/README.md
+++ b/cueit-kiosk/README.md
@@ -2,6 +2,8 @@
 
 A basic SwiftUI iPad kiosk application for submitting help desk tickets. The app fetches branding and text strings from the backend via the `/api/config` endpoint. These values are cached locally so the app can operate offline.
 
+When launched the kiosk registers itself with the backend using `/api/register-kiosk`. An administrator must activate the kiosk from the admin UI before it can be used in production.
+
 ## Building
 1. Open `CueIT Kiosk.xcodeproj` in Xcode 15 or later.
 2. Ensure the backend is running locally on the port defined in `cueit-backend/.env` (`API_PORT`).


### PR DESCRIPTION
## Summary
- document each sub-app with README files
- update main README with overview of all apps
- tweak admin navbar spacing and add new controls
- move config editor to a slide-out panel
- add kiosk management panel and backend API

## Testing
- `npm run lint` within `cueit-admin`
- `npm test` within `cueit-backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865cee397f08333be2780950fdbd358