### PR TITLE
Add automated setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ CueIT is an internal help desk application used to submit and track IT tickets. 
 
 ## Setup
 
+Run `./setup.sh` to install Node.js, SQLite and all project dependencies in one step.
+You can also follow the manual instructions below.
+
 ### Backend
 1. Navigate to `cueit-backend`.
 2. Run `npm install` to install dependencies.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure Node.js 18+ is installed
+if ! command -v node >/dev/null 2>&1 || \
+   [ "$(node -v | cut -d'v' -f2 | cut -d'.' -f1)" -lt 18 ]; then
+  echo "Installing Node.js 18..."
+  curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+  apt-get install -y nodejs
+fi
+
+# Install sqlite3 if missing
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "Installing sqlite3..."
+  apt-get update && apt-get install -y sqlite3
+fi
+
+# Optional: check Mailpit
+if ! command -v mailpit >/dev/null 2>&1; then
+  echo "Mailpit not found – install from https://github.com/axllent/mailpit if needed."
+fi
+
+# Install Node dependencies for backend and admin
+pushd cueit-backend >/dev/null
+npm ci
+popd >/dev/null
+
+pushd cueit-admin >/dev/null
+npm ci
+popd >/dev/null
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add setup.sh to install dependencies and system packages
- mention setup script in README

## Testing
- `npm run lint` within cueit-admin
- `npm test` within cueit-backend (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_6865d28fdce883338b993a2b479fd02b