### PR TITLE
Add UI tweaks and kiosk config

### DIFF
--- a/cueit-admin/.env
+++ b/cueit-admin/.env
@@ -1,2 +1,3 @@
 VITE_LOGO_URL=/logo.png
 VITE_API_URL=http://localhost:3000
+VITE_FAVICON_URL=/vite.svg

--- a/cueit-admin/index.html
+++ b/cueit-admin/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link id="favicon" rel="icon" type="image/png" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CueIT Admin</title>
   </head>

--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -48,7 +48,10 @@ function App() {
     [logs]
   );
 
-  const [config, setConfig] = useState({ logoUrl: import.meta.env.VITE_LOGO_URL });
+  const [config, setConfig] = useState({
+    logoUrl: import.meta.env.VITE_LOGO_URL,
+    faviconUrl: import.meta.env.VITE_FAVICON_URL,
+  });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -69,6 +72,13 @@ function App() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    const link = document.getElementById('favicon');
+    if (link && config.faviconUrl) {
+      link.href = config.faviconUrl;
+    }
+  }, [config.faviconUrl]);
+
   return (
     <>
       <Navbar
@@ -80,7 +90,7 @@ function App() {
         openConfig={() => setShowConfig(true)}
         openKiosks={() => setShowKiosks(true)}
       />
-      <div className="min-h-screen bg-gray-900 text-white pb-8">
+      <div className="min-h-screen bg-gray-900 text-white pb-8 flex flex-col">
         <div className="max-w-7xl mx-auto">
           {loading ? (
             <p className="text-gray-400 text-center">Loading logs...</p>
@@ -128,14 +138,14 @@ function App() {
                 <table className="min-w-full text-sm table-auto border-collapse rounded-lg overflow-hidden shadow-md">
                   <thead className="bg-gray-100 sticky top-0 z-10 text-sm font-semibold text-gray-900 tracking-wide">
                     <tr className="border-b border-gray-300">
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Ticket ID</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Name</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Email</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Title</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">System</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Urgency</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Email Status</th>
-                      <th className="px-6 py-3 text-left whitespace-nowrap">Submitted At</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Ticket ID</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Name</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Email</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Title</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">System</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Urgency</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Email Status</th>
+                      <th className="px-4 py-2 text-left whitespace-nowrap">Submitted At</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -173,6 +183,7 @@ function App() {
           )}
         </div>
       </div>
+      <footer className="text-center text-gray-400 py-4">CueIT Admin</footer>
       <ConfigPanel
         open={showConfig}
         onClose={() => setShowConfig(false)}

--- a/cueit-admin/src/ConfigPanel.jsx
+++ b/cueit-admin/src/ConfigPanel.jsx
@@ -23,6 +23,15 @@ export default function ConfigPanel({ open, onClose, config, setConfig, save }) 
             />
           </label>
           <label className="block">
+            Favicon URL
+            <input
+              type="text"
+              value={config.faviconUrl || ''}
+              onChange={(e) => setConfig({ ...config, faviconUrl: e.target.value })}
+              className="mt-1 w-full px-2 py-1 rounded text-black"
+            />
+          </label>
+          <label className="block">
             Welcome Message
             <input
               type="text"
@@ -43,6 +52,36 @@ export default function ConfigPanel({ open, onClose, config, setConfig, save }) 
           <button onClick={save} className="px-4 py-2 bg-blue-600 text-white rounded mt-2">
             Save
           </button>
+          <div className="pt-4 border-t border-gray-700 text-gray-300 text-xs space-y-2">
+            <div>Environment</div>
+            <label className="block">
+              API URL
+              <input
+                type="text"
+                value={import.meta.env.VITE_API_URL}
+                readOnly
+                className="mt-1 w-full px-2 py-1 rounded bg-gray-700 text-gray-400"
+              />
+            </label>
+            <label className="block">
+              Default Logo
+              <input
+                type="text"
+                value={import.meta.env.VITE_LOGO_URL}
+                readOnly
+                className="mt-1 w-full px-2 py-1 rounded bg-gray-700 text-gray-400"
+              />
+            </label>
+            <label className="block">
+              Default Favicon
+              <input
+                type="text"
+                value={import.meta.env.VITE_FAVICON_URL}
+                readOnly
+                className="mt-1 w-full px-2 py-1 rounded bg-gray-700 text-gray-400"
+              />
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/cueit-admin/src/KiosksPanel.jsx
+++ b/cueit-admin/src/KiosksPanel.jsx
@@ -16,6 +16,13 @@ export default function KiosksPanel({ open, onClose }) {
     setKiosks((k) => k.map((x) => (x.id === id ? { ...x, active: !active } : x)));
   };
 
+  const save = async (kiosk) => {
+    await axios.put(`${api}/api/kiosks/${kiosk.id}`, {
+      logoUrl: kiosk.logoUrl,
+      bgUrl: kiosk.bgUrl,
+    });
+  };
+
   return (
     <div
       className={`fixed inset-0 bg-black/50 z-60 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
@@ -33,7 +40,10 @@ export default function KiosksPanel({ open, onClose }) {
               <th className="pb-2">ID</th>
               <th className="pb-2">Version</th>
               <th className="pb-2">Last Seen</th>
+              <th className="pb-2">Logo URL</th>
+              <th className="pb-2">Background</th>
               <th className="pb-2">Active</th>
+              <th className="pb-2"></th>
             </tr>
           </thead>
           <tbody>
@@ -42,12 +52,36 @@ export default function KiosksPanel({ open, onClose }) {
                 <td className="py-1 pr-2 font-mono break-all">{k.id}</td>
                 <td className="py-1 pr-2">{k.version}</td>
                 <td className="py-1 pr-2 text-xs">{new Date(k.last_seen).toLocaleString()}</td>
+                <td className="py-1 pr-2">
+                  <input
+                    type="text"
+                    value={k.logoUrl || ''}
+                    onChange={(e) => setKiosks((ks) => ks.map((x) => x.id === k.id ? { ...x, logoUrl: e.target.value } : x))}
+                    className="w-28 px-1 text-black rounded"
+                  />
+                </td>
+                <td className="py-1 pr-2">
+                  <input
+                    type="text"
+                    value={k.bgUrl || ''}
+                    onChange={(e) => setKiosks((ks) => ks.map((x) => x.id === k.id ? { ...x, bgUrl: e.target.value } : x))}
+                    className="w-28 px-1 text-black rounded"
+                  />
+                </td>
                 <td className="py-1">
                   <button
                     onClick={() => toggle(k.id, k.active)}
                     className={`px-2 py-1 rounded text-xs ${k.active ? 'bg-green-600' : 'bg-red-600'}`}
                   >
                     {k.active ? 'Disable' : 'Activate'}
+                  </button>
+                </td>
+                <td className="py-1 pl-2">
+                  <button
+                    onClick={() => save(k)}
+                    className="px-2 py-1 rounded text-xs bg-blue-600"
+                  >
+                    Save
                   </button>
                 </td>
               </tr>

--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -14,8 +14,8 @@ export default function Navbar({
     <nav className="bg-blue-600 text-white shadow-md sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-6 py-2 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          {logo && <img src={logo} alt="Logo" className="h-[50px] w-[50px] object-contain" />}
-          <span className="text-xl font-semibold tracking-tight">CueIT Admin</span>
+          {logo && <img src={logo} alt="Logo" className="h-[60px] w-[60px] object-contain" />}
+          <span className="text-2xl font-bold tracking-tight">CueIT Admin</span>
         </div>
         <div className="flex items-center gap-4 pr-2">
           <div className="relative">
@@ -46,7 +46,7 @@ export default function Navbar({
               placeholder="Search..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className={`absolute right-0 top-1/2 -translate-y-1/2 bg-white text-black px-4 py-1 rounded-full w-56 transition-all duration-300 shadow ${showSearch ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-full'}`}
+              className={`absolute left-1/2 top-full mt-2 -translate-x-1/2 bg-white text-black px-4 py-1 rounded-full w-56 transition-all duration-300 shadow ${showSearch ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'}`}
             />
           </div>
         </div>

--- a/cueit-backend/db.js
+++ b/cueit-backend/db.js
@@ -29,16 +29,21 @@ db.serialize(() => {
       id TEXT PRIMARY KEY,
       last_seen TEXT,
       version TEXT,
-      active INTEGER DEFAULT 0
+      active INTEGER DEFAULT 0,
+      logoUrl TEXT,
+      bgUrl TEXT
     )
   `);
 
   // add active column if database was created with an older schema
   db.run(`ALTER TABLE kiosks ADD COLUMN active INTEGER DEFAULT 0`, () => {});
+  db.run(`ALTER TABLE kiosks ADD COLUMN logoUrl TEXT`, () => {});
+  db.run(`ALTER TABLE kiosks ADD COLUMN bgUrl TEXT`, () => {});
 
   // insert default config if not present
   const defaults = {
     logoUrl: process.env.LOGO_URL || '/logo.png',
+    faviconUrl: process.env.FAVICON_URL || '/vite.svg',
     welcomeMessage: 'Welcome to the Help Desk',
     helpMessage: 'Need to report an issue?',
     adminPassword: 'admin'

--- a/cueit-backend/index.js
+++ b/cueit-backend/index.js
@@ -116,6 +116,26 @@ app.post("/api/register-kiosk", (req, res) => {
   );
 });
 
+app.get("/api/kiosks/:id", (req, res) => {
+  db.get(`SELECT * FROM kiosks WHERE id=?`, [req.params.id], (err, row) => {
+    if (err) return res.status(500).json({ error: "DB error" });
+    res.json(row || {});
+  });
+});
+
+app.put("/api/kiosks/:id", (req, res) => {
+  const { id } = req.params;
+  const { logoUrl, bgUrl, active } = req.body;
+  db.run(
+    `UPDATE kiosks SET logoUrl=?, bgUrl=?, active=COALESCE(?, active) WHERE id=?`,
+    [logoUrl, bgUrl, active !== undefined ? (active ? 1 : 0) : null, id],
+    (err) => {
+      if (err) return res.status(500).json({ error: "DB error" });
+      res.json({ message: "updated" });
+    }
+  );
+});
+
 app.get("/api/kiosks", (req, res) => {
   db.all(`SELECT * FROM kiosks`, (err, rows) => {
     if (err) return res.status(500).json({ error: "DB error" });

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -14,7 +14,17 @@ struct LaunchView: View {
 
     var body: some View {
         ZStack {
-            Color.white.edgesIgnoringSafeArea(.all)
+            if let bg = configService.config.backgroundUrl,
+               let url = URL(string: bg) {
+                AsyncImage(url: url) { img in
+                    img.resizable().scaledToFill()
+                } placeholder: {
+                    Color.white
+                }
+                .ignoresSafeArea()
+            } else {
+                Color.white.ignoresSafeArea()
+            }
             VStack {
                 AsyncImage(url: URL(string: configService.config.logoUrl)) { img in
                     img.resizable()


### PR DESCRIPTION
## Summary
- adjust layout for the navbar search box
- increase logo size and make title bold
- show favicon from config and allow editing in admin
- display environment variables in config panel (read‑only)
- add footer
- refine table header spacing
- extend kiosk panel to manage logo/background
- store per‑kiosk assets in backend and expose new API endpoints
- allow kiosks to download logo and background and show background image

## Testing
- `npm run lint` in `cueit-admin`
- `npm install` in `cueit-admin`
- `npm install` in `cueit-backend`
- `npm test` in `cueit-backend` *(fails: "Error: no test specified")*
- `npm test` in `cueit-admin` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865d5b9b03c833381610907b2c3ca21