### PR TITLE
Add backend and frontend tests

### DIFF
--- a/cueit-admin/babel.config.cjs
+++ b/cueit-admin/babel.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ],
+  plugins: ['babel-plugin-transform-vite-meta-env']
+};

--- a/cueit-admin/jest.config.cjs
+++ b/cueit-admin/jest.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
+  }
+};

--- a/cueit-admin/jest.setup.js
+++ b/cueit-admin/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/cueit-admin/package.json
+++ b/cueit-admin/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
@@ -16,15 +17,25 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.24.1",
+    "@babel/preset-react": "^7.22.5",
     "@eslint/js": "^9.29.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
     "autoprefixer": "^10.4.21",
+    "babel-jest": "^29.7.0",
+    "babel-plugin-transform-vite-meta-env": "^1.0.3",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.0"

--- a/cueit-admin/src/__tests__/App.test.jsx
+++ b/cueit-admin/src/__tests__/App.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import App from '../App.jsx';
+
+jest.mock('axios');
+
+const logs = [
+  { ticket_id: '1', name: 'Alice', email: 'a@x.com', title: 'A', system: 'Sys1', urgency: 'High', email_status: 'success', timestamp: '2024-05-01T10:00:00Z' },
+  { ticket_id: '2', name: 'Bob', email: 'b@x.com', title: 'B', system: 'Sys2', urgency: 'Low', email_status: 'success', timestamp: '2024-05-02T10:00:00Z' }
+];
+
+beforeEach(() => {
+  process.env.VITE_API_URL = 'http://localhost';
+  axios.get.mockImplementation((url) => {
+    if (url.endsWith('/api/logs')) return Promise.resolve({ data: logs });
+    if (url.endsWith('/api/config')) return Promise.resolve({ data: {} });
+  });
+  axios.put.mockResolvedValue({});
+});
+
+describe('App filtering and config', () => {
+  test('filters logs by search and sorts by name', async () => {
+    render(<App />);
+    await screen.findByText('Alice');
+    const searchBtn = screen.getByLabelText('Toggle Search');
+    await userEvent.click(searchBtn);
+    const searchInput = screen.getByPlaceholderText('Search...');
+    await userEvent.type(searchInput, 'Bob');
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.queryByText('Alice')).toBeNull();
+    await userEvent.clear(searchInput);
+    await userEvent.selectOptions(screen.getByDisplayValue('Sort by Date'), 'name');
+    const rows = screen.getAllByRole('row');
+    expect(within(rows[1]).getByText('Alice')).toBeInTheDocument();
+  });
+
+  test('saves config via axios and updates logo url', async () => {
+    render(<App />);
+    await screen.findByText('Alice');
+    await userEvent.click(screen.getByLabelText('Settings'));
+    await userEvent.click(screen.getByText('Config'));
+    const logoInput = screen.getByLabelText('Logo URL');
+    await userEvent.clear(logoInput);
+    await userEvent.type(logoInput, 'newlogo.png');
+    window.alert = jest.fn();
+    await userEvent.click(screen.getByText('Save'));
+    expect(axios.put).toHaveBeenCalledWith('http://localhost/api/config', expect.objectContaining({ logoUrl: 'newlogo.png' }));
+    expect(screen.getByAltText('Logo').src).toContain('newlogo.png');
+  });
+});

--- a/cueit-admin/src/__tests__/ConfigPanel.test.jsx
+++ b/cueit-admin/src/__tests__/ConfigPanel.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfigPanel from '../ConfigPanel.jsx';
+
+describe('ConfigPanel', () => {
+  test('calls save when Save button is clicked', async () => {
+    const save = jest.fn();
+    const setConfig = jest.fn();
+    const config = { logoUrl: 'a', faviconUrl: 'b', welcomeMessage: 'hi', helpMessage: 'help' };
+    render(<ConfigPanel open={true} onClose={() => {}} config={config} setConfig={setConfig} save={save} />);
+    await userEvent.click(screen.getByText('Save'));
+    expect(save).toHaveBeenCalled();
+  });
+});

--- a/cueit-admin/src/__tests__/KiosksPanel.test.jsx
+++ b/cueit-admin/src/__tests__/KiosksPanel.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import KiosksPanel from '../KiosksPanel.jsx';
+
+jest.mock('axios');
+
+const kiosk = { id: 'k1', version: '1', last_seen: '2024-01-01T00:00:00Z', active: 0 };
+
+describe('KiosksPanel', () => {
+  test('toggles kiosk active state', async () => {
+    axios.get.mockResolvedValueOnce({ data: [kiosk] });
+    axios.put.mockResolvedValue({});
+    render(<KiosksPanel open={true} onClose={() => {}} />);
+    expect(await screen.findByText('k1')).toBeInTheDocument();
+    const toggleBtn = screen.getByRole('button', { name: /activate/i });
+    await userEvent.click(toggleBtn);
+    expect(axios.put).toHaveBeenCalledWith(expect.stringContaining('/api/kiosks/k1/active'), { active: true });
+    expect(toggleBtn.textContent.toLowerCase()).toContain('disable');
+  });
+});

--- a/cueit-backend/test/00_setup.js
+++ b/cueit-backend/test/00_setup.js
@@ -1,0 +1,19 @@
+const nodemailer = require('nodemailer');
+let sendBehavior = async () => {};
+const originalCreate = nodemailer.createTransport;
+
+nodemailer.createTransport = () => ({
+  sendMail: (opts) => sendBehavior(opts),
+});
+
+const app = require('../index');
+
+global.app = app;
+
+global.setSendBehavior = (fn) => {
+  sendBehavior = fn;
+};
+
+after(() => {
+  nodemailer.createTransport = originalCreate;
+});

--- a/cueit-backend/test/config.test.js
+++ b/cueit-backend/test/config.test.js
@@ -1,0 +1,50 @@
+const request = require('supertest');
+const assert = require('assert');
+const db = require('../db');
+const app = global.app;
+
+const defaults = {
+  logoUrl: '/logo.png',
+  faviconUrl: '/vite.svg',
+  welcomeMessage: 'Welcome to the Help Desk',
+  helpMessage: 'Need to report an issue?',
+  adminPassword: 'admin',
+};
+
+function resetDb(done) {
+  db.serialize(() => {
+    db.run('DELETE FROM logs');
+    db.run('DELETE FROM config');
+    const stmt = db.prepare('INSERT INTO config (key, value) VALUES (?, ?)');
+    for (const [k, v] of Object.entries(defaults)) {
+      stmt.run(k, v);
+    }
+    stmt.finalize(done);
+  });
+}
+
+beforeEach((done) => {
+  resetDb(done);
+});
+
+describe('Config endpoints', function () {
+  it('GET /api/config returns defaults', function () {
+    return request(app)
+      .get('/api/config')
+      .expect(200)
+      .expect((res) => {
+        for (const [k, v] of Object.entries(defaults)) {
+          assert.strictEqual(res.body[k], v);
+        }
+      });
+  });
+
+  it('PUT /api/config updates and persists values', async function () {
+    const updates = { logoUrl: 'new.png', welcomeMessage: 'Hi' };
+    await request(app).put('/api/config').send(updates).expect(200);
+
+    const res = await request(app).get('/api/config').expect(200);
+    assert.strictEqual(res.body.logoUrl, 'new.png');
+    assert.strictEqual(res.body.welcomeMessage, 'Hi');
+  });
+});

--- a/cueit-backend/test/kiosk.test.js
+++ b/cueit-backend/test/kiosk.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const assert = require('assert');
-const app = require('../index');
+const app = global.app || require('../index');
 const db = require('../db');
 
 beforeEach((done) => {

--- a/cueit-backend/test/submit-ticket.test.js
+++ b/cueit-backend/test/submit-ticket.test.js
@@ -1,0 +1,89 @@
+const request = require('supertest');
+const assert = require('assert');
+const db = require('../db');
+const app = global.app;
+
+function resetDb(done) {
+  const defaults = {
+    logoUrl: '/logo.png',
+    faviconUrl: '/vite.svg',
+    welcomeMessage: 'Welcome to the Help Desk',
+    helpMessage: 'Need to report an issue?',
+    adminPassword: 'admin',
+  };
+  db.serialize(() => {
+    db.run('DELETE FROM logs');
+    db.run('DELETE FROM config');
+    const stmt = db.prepare('INSERT INTO config (key, value) VALUES (?, ?)');
+    for (const [k, v] of Object.entries(defaults)) {
+      stmt.run(k, v);
+    }
+    stmt.finalize(done);
+  });
+}
+
+beforeEach((done) => {
+  global.setSendBehavior(() => Promise.resolve());
+  resetDb(done);
+});
+
+describe('POST /submit-ticket', function () {
+  it('returns 400 when required fields are missing', function () {
+    return request(app)
+      .post('/submit-ticket')
+      .send({ name: 'John' })
+      .expect(400)
+      .expect((res) => {
+        assert.strictEqual(res.body.error, 'Missing required fields');
+      });
+  });
+
+  it('returns 200 and logs entry on success', async function () {
+    let called = false;
+    global.setSendBehavior(async () => { called = true; });
+
+    const payload = {
+      name: 'Alice',
+      email: 'a@example.com',
+      title: 'Test',
+      system: 'Sys',
+      urgency: 'High',
+      description: 'Desc',
+    };
+
+    const res = await request(app).post('/submit-ticket').send(payload).expect(200);
+    assert.strictEqual(called, true, 'sendMail not called');
+    assert.strictEqual(res.body.emailStatus, 'success');
+
+    const row = await new Promise((resolve) => {
+      db.get('SELECT * FROM logs WHERE ticket_id=?', [res.body.ticketId], (err, r) => {
+        resolve(r);
+      });
+    });
+    assert(row, 'log row missing');
+    assert.strictEqual(row.email_status, 'success');
+  });
+
+  it('sets emailStatus to fail when sendMail throws', async function () {
+    global.setSendBehavior(async () => { throw new Error('smtp error'); });
+
+    const payload = {
+      name: 'Bob',
+      email: 'b@example.com',
+      title: 'Fail',
+      system: 'Sys',
+      urgency: 'Low',
+    };
+
+    const res = await request(app).post('/submit-ticket').send(payload).expect(200);
+    assert.strictEqual(res.body.emailStatus, 'fail');
+
+    const row = await new Promise((resolve) => {
+      db.get('SELECT * FROM logs WHERE ticket_id=?', [res.body.ticketId], (err, r) => {
+        resolve(r);
+      });
+    });
+    assert(row, 'log row missing');
+    assert.strictEqual(row.email_status, 'fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha tests for ticket submission and config routes
- mock nodemailer via test setup
- add React component tests using Jest and Testing Library
- configure Jest with Babel for vite-style environment

## Testing
- `npm test --silent` in `cueit-backend`
- `npx jest --runInBand` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_6865e79d90f4833385dae4c6be376d08