### PR TITLE
Add error handling for axios requests

### DIFF
--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -189,14 +189,6 @@ function App() {
         onClose={() => setShowConfig(false)}
         config={config}
         setConfig={setConfig}
-        save={async () => {
-          try {
-            await axios.put(`${import.meta.env.VITE_API_URL}/api/config`, config);
-            alert('Saved');
-          } catch {
-            alert('Failed');
-          }
-        }}
       />
       <KiosksPanel open={showKiosks} onClose={() => setShowKiosks(false)} />
     </>

--- a/cueit-admin/src/ConfigPanel.jsx
+++ b/cueit-admin/src/ConfigPanel.jsx
@@ -1,6 +1,18 @@
 import React from 'react';
+import axios from 'axios';
 
-export default function ConfigPanel({ open, onClose, config, setConfig, save }) {
+export default function ConfigPanel({ open, onClose, config, setConfig }) {
+  const api = import.meta.env.VITE_API_URL;
+
+  const saveConfig = async () => {
+    try {
+      await axios.put(`${api}/api/config`, config);
+      alert('Saved');
+    } catch (err) {
+      alert('Failed to save configuration');
+    }
+  };
+
   return (
     <div
       className={`fixed inset-0 bg-black/50 z-60 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
@@ -49,7 +61,7 @@ export default function ConfigPanel({ open, onClose, config, setConfig, save }) 
               className="mt-1 w-full px-2 py-1 rounded text-black"
             />
           </label>
-          <button onClick={save} className="px-4 py-2 bg-blue-600 text-white rounded mt-2">
+          <button onClick={saveConfig} className="px-4 py-2 bg-blue-600 text-white rounded mt-2">
             Save
           </button>
           <div className="pt-4 border-t border-gray-700 text-gray-300 text-xs space-y-2">

--- a/cueit-admin/src/KiosksPanel.jsx
+++ b/cueit-admin/src/KiosksPanel.jsx
@@ -7,20 +7,37 @@ export default function KiosksPanel({ open, onClose }) {
 
   useEffect(() => {
     if (open) {
-      axios.get(`${api}/api/kiosks`).then((res) => setKiosks(res.data));
+      (async () => {
+        try {
+          const res = await axios.get(`${api}/api/kiosks`);
+          setKiosks(res.data);
+        } catch (err) {
+          alert('Failed to load kiosks');
+        }
+      })();
     }
   }, [open, api]);
 
   const toggle = async (id, active) => {
-    await axios.put(`${api}/api/kiosks/${id}/active`, { active: !active });
-    setKiosks((k) => k.map((x) => (x.id === id ? { ...x, active: !active } : x)));
+    try {
+      await axios.put(`${api}/api/kiosks/${id}/active`, { active: !active });
+      setKiosks((k) =>
+        k.map((x) => (x.id === id ? { ...x, active: !active } : x))
+      );
+    } catch (err) {
+      alert('Failed to toggle kiosk');
+    }
   };
 
   const save = async (kiosk) => {
-    await axios.put(`${api}/api/kiosks/${kiosk.id}`, {
-      logoUrl: kiosk.logoUrl,
-      bgUrl: kiosk.bgUrl,
-    });
+    try {
+      await axios.put(`${api}/api/kiosks/${kiosk.id}`, {
+        logoUrl: kiosk.logoUrl,
+        bgUrl: kiosk.bgUrl,
+      });
+    } catch (err) {
+      alert('Failed to save kiosk');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- show alerts when kiosk API calls fail
- allow ConfigPanel to save itself and report errors

## Testing
- `npm test` *(fails: invalid ELF header sqlite3)*
- `npm run lint` in `cueit-admin` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865eab2e58083338c99eb8d8865cc3b