### PR TITLE
Improve search UX in admin navbar

### DIFF
--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -47,13 +47,25 @@ export default function Navbar({
             >
               🔍
             </button>
-            <input
-              type="text"
-              placeholder="Search..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className={`absolute left-1/2 top-full mt-2 -translate-x-1/2 bg-gray-100 text-black px-4 py-1 rounded-full w-56 border border-gray-300 shadow transition-all duration-300 z-20 ${showSearch ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'}`}
-            />
+            <div className="relative">
+              <input
+                type="text"
+                placeholder="Search..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className={`pl-3 pr-6 absolute left-1/2 top-full mt-2 -translate-x-1/2 bg-gray-100 text-black py-1 rounded-full w-56 border border-gray-300 shadow transition-all duration-300 z-20 ${showSearch ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'} sm:static sm:opacity-100 sm:translate-y-0 sm:pointer-events-auto sm:mt-0 sm:ml-2`}
+              />
+              {search && (
+                <button
+                  type="button"
+                  aria-label="Clear search"
+                  onClick={() => setSearch('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                >
+                  ×
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/cueit-admin/src/__tests__/App.test.jsx
+++ b/cueit-admin/src/__tests__/App.test.jsx
@@ -29,7 +29,9 @@ describe('App filtering and config', () => {
     await userEvent.type(searchInput, 'Bob');
     expect(screen.getByText('Bob')).toBeInTheDocument();
     expect(screen.queryByText('Alice')).toBeNull();
-    await userEvent.clear(searchInput);
+    const clearBtn = within(searchInput.parentElement).getByLabelText('Clear search');
+    await userEvent.click(clearBtn);
+    expect(searchInput).toHaveValue('');
     await userEvent.selectOptions(screen.getByDisplayValue('Sort by Date'), 'name');
     const rows = screen.getAllByRole('row');
     expect(within(rows[1]).getByText('Alice')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- keep search box visible on desktop viewport
- allow clearing the search from a button inside the field
- test clearing search in App tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865f24f64188333ab000243201eb9a0