### PR TITLE
Fix search input label

### DIFF
--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -72,6 +72,7 @@ export default function Navbar({
               <input
                 type="text"
                 placeholder="Search..."
+                aria-label="Search"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className={`pl-3 pr-6 absolute left-1/2 top-full mt-2 -translate-x-1/2 bg-gray-100 text-black py-1 rounded-full w-56 border border-gray-300 shadow transition-all duration-300 z-20 ${showSearch ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'} sm:static sm:opacity-100 sm:translate-y-0 sm:pointer-events-auto sm:mt-0 sm:ml-2`}


### PR DESCRIPTION
## Summary
- add missing `aria-label` attribute for the search bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865f8ba93f883339d805bc904a1110d