### PR TITLE
Fix user list update on new user creation

### DIFF
--- a/cueit-admin/src/UsersPanel.jsx
+++ b/cueit-admin/src/UsersPanel.jsx
@@ -21,7 +21,7 @@ export default function UsersPanel({ open }) {
   const addUser = async () => {
     try {
       const res = await axios.post(`${api}/api/users`, { name: '', email: '' });
-      setUsers([...users, { id: res.data.id, name: '', email: '' }]);
+      setUsers((prev) => [...prev, { id: res.data.id, name: '', email: '' }]);
     } catch (err) {
       alert('Failed to add user');
     }


### PR DESCRIPTION
## Summary
- correct state update logic when adding users in the admin panel

## Testing
- `npm test` in `cueit-backend`
- `npm test --silent` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_6865f8bb3eb08333a9f946f58291af9a