### PR TITLE
Add kiosk activation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # CueIT
 
-CueIT is an internal help desk application used to submit and track IT tickets. The repository contains four apps:
+CueIT is an internal help desk application used to submit and track IT tickets. The repository contains several apps:
 
 - **cueit-backend** – Express/SQLite API
 - **cueit-admin** – React admin interface
 - **cueit-kiosk** – iPad kiosk for ticket submission
-
+- **cueit-activate** – small React app for activating kiosks
 - **cueit-slack** – Slack slash command integration
 
 ## Requirements
@@ -31,6 +31,12 @@ You can also follow the manual instructions below.
 2. Run `npm install` to install dependencies.
 3. Create a `.env` file and set `VITE_API_URL` and `VITE_LOGO_URL`.
 4. Start the development server with `npm run dev` and open `http://localhost:5173`.
+
+### Activation Page
+1. Navigate to `cueit-activate`.
+2. Run `npm install` to install dependencies.
+3. Create a `.env` file with `VITE_API_URL`.
+4. Start the dev server with `npm run dev` and open the page to activate kiosks.
 
 The backend stores ticket logs in a local SQLite database (`cueit-backend/log.sqlite`).
 Configuration values are stored in the same database and can be edited from the admin UI.

--- a/cueit-activate/README.md
+++ b/cueit-activate/README.md
@@ -1,0 +1,8 @@
+# CueIT Activate
+
+A minimal React page for activating kiosks.
+
+## Setup
+1. Run `npm install` in this folder.
+2. Create a `.env` with `VITE_API_URL` pointing to the backend.
+3. Start the dev server with `npm run dev`.

--- a/cueit-activate/index.html
+++ b/cueit-activate/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kiosk Activation</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/cueit-activate/package.json
+++ b/cueit-activate/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cueit-activate",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.10.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.2",
+    "vite": "^7.0.0"
+  }
+}

--- a/cueit-activate/src/App.jsx
+++ b/cueit-activate/src/App.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function App() {
+  const [kioskId, setKioskId] = useState('');
+  const [message, setMessage] = useState('');
+
+  const activate = async () => {
+    if (!kioskId) return;
+    try {
+      const api = import.meta.env.VITE_API_URL;
+      await axios.put(`${api}/api/kiosks/${kioskId}/active`, { active: true });
+      setMessage('Kiosk activated');
+    } catch (err) {
+      setMessage('Activation failed');
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginTop: '2rem' }}>
+      <h1>Kiosk Activation</h1>
+      <input
+        type="text"
+        value={kioskId}
+        onChange={(e) => setKioskId(e.target.value)}
+        placeholder="Enter kiosk ID"
+        style={{ padding: '0.5rem', marginBottom: '1rem', width: '200px' }}
+      />
+      <button onClick={activate} style={{ padding: '0.5rem 1rem' }}>Activate</button>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/cueit-activate/src/main.jsx
+++ b/cueit-activate/src/main.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/cueit-activate/vite.config.js
+++ b/cueit-activate/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ if ! command -v mailpit >/dev/null 2>&1; then
   echo "Mailpit not found – install from https://github.com/axllent/mailpit if needed."
 fi
 
-# Install Node dependencies for backend, admin and Slack service
+# Install Node dependencies for backend, admin, activate page and Slack service
 pushd cueit-backend >/dev/null
 npm ci
 popd >/dev/null
@@ -28,6 +28,12 @@ popd >/dev/null
 pushd cueit-admin >/dev/null
 npm ci
 popd >/dev/null
+
+if [ -d cueit-activate ]; then
+  pushd cueit-activate >/dev/null
+  npm ci
+  popd >/dev/null
+fi
 
 if [ -d cueit-slack ]; then
   pushd cueit-slack >/dev/null


### PR DESCRIPTION
## Summary
- add `cueit-activate` React app to enable kiosk activation
- document activation page in root README
- install dependencies for the new app in `setup.sh`

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6865fa8719188333b2ff3788e0189590