### PR TITLE
Add local Slack testing docs and port env

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ Configuration values are stored in the same database and can be edited from the 
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
    - `BACKEND_URL`
-   - optional `SLACK_PORT`
-4. Start the service with `node index.js`.
+   - optional `SLACK_PORT` (defaults to `3001`)
+ 4. Start the service with `node index.js`. It listens on `SLACK_PORT`.
+ 5. For local testing expose the port with `ngrok` and use the HTTPS URL in your Slack command:
+
+```bash
+npx ngrok http $SLACK_PORT
+```
 
 ## Testing the API
 

--- a/cueit-slack/.env.example
+++ b/cueit-slack/.env.example
@@ -1,0 +1,4 @@
+SLACK_SIGNING_SECRET=your-secret
+SLACK_BOT_TOKEN=xoxb-your-token
+BACKEND_URL=http://localhost:3000
+SLACK_PORT=3001

--- a/cueit-slack/README.md
+++ b/cueit-slack/README.md
@@ -1,0 +1,21 @@
+# CueIT Slack Service
+
+Slack slash command integration that lets users submit tickets directly from Slack.
+
+## Setup
+1. Run `npm install` in this directory.
+2. Create a `.env` file with the following variables:
+   - `SLACK_SIGNING_SECRET`
+   - `SLACK_BOT_TOKEN`
+   - `BACKEND_URL`
+   - optional `SLACK_PORT` (defaults to `3001`)
+3. Start the service with `node index.js`.
+
+## Local Testing
+Slack slash commands require a public HTTPS endpoint. While developing you can expose your local service using [ngrok](https://ngrok.com/):
+
+```bash
+npx ngrok http $SLACK_PORT
+```
+
+Use the HTTPS forwarding address printed by ngrok as the request URL for your `/new-ticket` command.

--- a/cueit-slack/index.js
+++ b/cueit-slack/index.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const { App } = require('@slack/bolt');
 const axios = require('axios');
 
+const PORT = process.env.SLACK_PORT || 3001;
+
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   token: process.env.SLACK_BOT_TOKEN,
@@ -102,7 +104,6 @@ app.view('ticket_submit', async ({ ack, body, view, client }) => {
 });
 
 (async () => {
-  const port = process.env.SLACK_PORT || 3001;
-  await app.start(port);
-  console.log(`✅ CueIT Slack service running on port ${port}`);
+  await app.start(PORT);
+  console.log(`✅ CueIT Slack service running on port ${PORT}`);
 })();


### PR DESCRIPTION
## Summary
- document how to run the Slack service locally using ngrok
- clarify the `SLACK_PORT` env var and default port
- add README and example env for `cueit-slack`
- expose `SLACK_PORT` via constant in the Slack service

## Testing
- `npm test` in `cueit-backend`
- `npm test` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_6866023c31c88333aa89ca8ecb255959