### PR TITLE
Add toast notifications to admin UI

### DIFF
--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import UsersPanel from './UsersPanel.jsx';
+import { useToast } from './Toast.jsx';
 
 export default function SettingsPanel({ open, onClose, config, setConfig }) {
   const [tab, setTab] = useState('general');
   const [kiosks, setKiosks] = useState([]);
   const api = import.meta.env.VITE_API_URL;
+  const toast = useToast();
 
   useEffect(() => {
     if (open && tab === 'kiosks') {
@@ -14,7 +16,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
           const res = await axios.get(`${api}/api/kiosks`);
           setKiosks(res.data);
         } catch (err) {
-          alert('Failed to load kiosks');
+          toast('Failed to load kiosks', 'error');
         }
       })();
     }
@@ -23,9 +25,9 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
   const saveConfig = async () => {
     try {
       await axios.put(`${api}/api/config`, config);
-      alert('Saved');
+      toast('Configuration saved');
     } catch (err) {
-      alert('Failed to save configuration');
+      toast('Failed to save configuration', 'error');
     }
   };
 
@@ -34,7 +36,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
       await axios.put(`${api}/api/kiosks/${id}/active`, { active: !active });
       setKiosks((k) => k.map((x) => (x.id === id ? { ...x, active: !active } : x)));
     } catch (err) {
-      alert('Failed to toggle kiosk');
+      toast('Failed to toggle kiosk', 'error');
     }
   };
 
@@ -45,7 +47,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
         bgUrl: kiosk.bgUrl,
       });
     } catch (err) {
-      alert('Failed to save kiosk');
+      toast('Failed to save kiosk', 'error');
     }
   };
 

--- a/cueit-admin/src/Toast.jsx
+++ b/cueit-admin/src/Toast.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ToastContext = createContext(() => {});
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const show = (message, type = 'info') => {
+    const id = Date.now() + Math.random();
+    setToasts((t) => [...t, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((x) => x.id !== id));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={show}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`px-4 py-2 rounded shadow text-white ${
+              t.type === 'error' ? 'bg-red-600' : 'bg-green-600'
+            }`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastContext);
+

--- a/cueit-admin/src/UsersPanel.jsx
+++ b/cueit-admin/src/UsersPanel.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { useToast } from './Toast.jsx';
 
 export default function UsersPanel({ open }) {
   const [users, setUsers] = useState([]);
   const api = import.meta.env.VITE_API_URL;
+  const toast = useToast();
 
   useEffect(() => {
     if (open) {
@@ -12,7 +14,7 @@ export default function UsersPanel({ open }) {
           const res = await axios.get(`${api}/api/users`);
           setUsers(res.data);
         } catch (err) {
-          alert('Failed to load users');
+          toast('Failed to load users', 'error');
         }
       })();
     }
@@ -23,7 +25,7 @@ export default function UsersPanel({ open }) {
       const res = await axios.post(`${api}/api/users`, { name: '', email: '' });
       setUsers(prev => [...prev, { id: res.data.id, name: '', email: '' }]);
     } catch (err) {
-      alert('Failed to add user');
+      toast('Failed to add user', 'error');
     }
   };
 
@@ -34,7 +36,7 @@ export default function UsersPanel({ open }) {
         email: u.email,
       });
     } catch (err) {
-      alert('Failed to save user');
+      toast('Failed to save user', 'error');
     }
   };
 
@@ -43,7 +45,7 @@ export default function UsersPanel({ open }) {
       await axios.delete(`${api}/api/users/${id}`);
       setUsers((us) => us.filter((x) => x.id !== id));
     } catch (err) {
-      alert('Failed to delete user');
+      toast('Failed to delete user', 'error');
     }
   };
 

--- a/cueit-admin/src/main.jsx
+++ b/cueit-admin/src/main.jsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import '@fortawesome/fontawesome-free/css/all.min.css'
 import App from './App.jsx'
+import { ToastProvider } from './Toast.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add basic Toast component and provider
- wire up ToastProvider in `main.jsx`
- show toast errors in SettingsPanel and UsersPanel instead of `alert`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866041561f4833381d197e2133cfaaf