### PR TITLE
Add shared theme across UI projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ CueIT is an internal help desk application used to submit and track IT tickets. 
 - **cueit-activate** – small React app for activating kiosks
 - **cueit-slack** – Slack slash command integration
 
+The `design/theme.js` file defines shared colors, fonts and spacing. Frontends
+import these tokens so styles remain consistent across the admin UI, activation
+page and SwiftUI kiosk app.
+
 ## Requirements
 - [Node.js](https://nodejs.org/) 18 or higher
 - npm

--- a/cueit-activate/README.md
+++ b/cueit-activate/README.md
@@ -6,3 +6,9 @@ A minimal React page for activating kiosks.
 1. Run `npm install` in this folder.
 2. Create a `.env` with `VITE_API_URL` pointing to the backend.
 3. Start the dev server with `npm run dev`.
+
+### Theme
+
+This page also consumes the shared design tokens in `../../design/theme.js` via
+`src/theme.js`. Use these values when styling new components so colors and
+spacing stay consistent with the rest of the project.

--- a/cueit-activate/src/App.jsx
+++ b/cueit-activate/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import axios from 'axios';
+import theme from '../../design/theme.js';
 
 export default function App() {
   const [kioskId, setKioskId] = useState('');
@@ -17,17 +18,43 @@ export default function App() {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', marginTop: '2rem' }}>
-      <h1>Kiosk Activation</h1>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        marginTop: theme.spacing.lg,
+        fontFamily: theme.fonts.sans.join(','),
+        color: theme.colors.content,
+      }}
+    >
+      <h1 style={{ marginBottom: theme.spacing.md }}>Kiosk Activation</h1>
       <input
         type="text"
         value={kioskId}
         onChange={(e) => setKioskId(e.target.value)}
         placeholder="Enter kiosk ID"
-        style={{ padding: '0.5rem', marginBottom: '1rem', width: '200px' }}
+        style={{
+          padding: theme.spacing.sm,
+          marginBottom: theme.spacing.md,
+          width: '200px',
+          border: `1px solid ${theme.colors.secondary}`,
+          borderRadius: '4px',
+        }}
       />
-      <button onClick={activate} style={{ padding: '0.5rem 1rem' }}>Activate</button>
-      {message && <p>{message}</p>}
+      <button
+        onClick={activate}
+        style={{
+          padding: `${theme.spacing.sm} ${theme.spacing.md}`,
+          backgroundColor: theme.colors.primary,
+          color: theme.colors.base,
+          border: 'none',
+          borderRadius: '4px',
+        }}
+      >
+        Activate
+      </button>
+      {message && <p style={{ marginTop: theme.spacing.md }}>{message}</p>}
     </div>
   );
 }

--- a/cueit-activate/src/theme.js
+++ b/cueit-activate/src/theme.js
@@ -1,0 +1,2 @@
+export { default } from '../../design/theme.js';
+export * from '../../design/theme.js';

--- a/cueit-admin/README.md
+++ b/cueit-admin/README.md
@@ -10,3 +10,10 @@ React based interface for viewing help desk tickets and managing system settings
 The admin UI lets you search tickets, edit configuration values, activate kiosk devices and manage users from the new **Users** tab in Settings.
 Font Awesome is loaded via CDN in `index.html` to provide icons throughout the interface.
 
+### Theme
+
+Design tokens live in `../../design/theme.js`. Import from `src/theme.js` to use
+the same colors, fonts and spacing across components. Tailwind and DaisyUI are
+configured to read from this file so any new pages should reference these
+tokens.
+

--- a/cueit-admin/src/theme.js
+++ b/cueit-admin/src/theme.js
@@ -1,0 +1,2 @@
+export { default } from '../../design/theme.js';
+export * from '../../design/theme.js';

--- a/cueit-admin/tailwind.config.js
+++ b/cueit-admin/tailwind.config.js
@@ -1,15 +1,35 @@
 import daisyui from 'daisyui';
+import theme from '../design/theme.js';
+
 export default {
   content: ['./index.html', './src/**/*.{js,jsx}'],
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
+        sans: theme.fonts.sans,
+      },
+      spacing: theme.spacing,
+      colors: {
+        primary: theme.colors.primary,
+        secondary: theme.colors.secondary,
+        accent: theme.colors.accent,
       },
     },
   },
   plugins: [daisyui],
   daisyui: {
-    themes: ['light', 'dark'],
+    themes: [
+      {
+        cueit: {
+          primary: theme.colors.primary,
+          secondary: theme.colors.secondary,
+          accent: theme.colors.accent,
+          'base-100': theme.colors.base,
+          'base-content': theme.colors.content,
+        },
+      },
+      'light',
+      'dark',
+    ],
   },
 };

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Theme.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Theme.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct Theme {
+    struct Colors {
+        static let primary = Color(hex: "#1D4ED8")
+        static let secondary = Color(hex: "#9333EA")
+        static let accent = Color(hex: "#F97316")
+        static let base = Color(hex: "#ffffff")
+        static let content = Color(hex: "#1f2937")
+    }
+
+    struct Spacing {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 16
+        static let lg: CGFloat = 32
+    }
+}
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
@@ -25,7 +25,7 @@ struct AdminLoginView: View {
 
                 if showError {
                     Text("Incorrect password")
-                        .foregroundColor(.red)
+                        .foregroundColor(Theme.Colors.accent)
                         .font(.subheadline)
                 }
 
@@ -36,9 +36,12 @@ struct AdminLoginView: View {
                         showError = true
                     }
                 }
-                .padding()
+                .padding(Theme.Spacing.sm)
+                .background(Theme.Colors.primary)
+                .foregroundColor(Theme.Colors.base)
+                .cornerRadius(8)
             }
-            .padding()
+            .padding(Theme.Spacing.md)
             .navigationTitle("Admin Login")
         }
     }

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -19,11 +19,11 @@ struct LaunchView: View {
                 AsyncImage(url: url) { img in
                     img.resizable().scaledToFill()
                 } placeholder: {
-                    Color.white
+                    Theme.Colors.base
                 }
                 .ignoresSafeArea()
             } else {
-                Color.white.ignoresSafeArea()
+                Theme.Colors.base.ignoresSafeArea()
             }
             VStack {
                 AsyncImage(url: URL(string: configService.config.logoUrl)) { img in
@@ -33,7 +33,7 @@ struct LaunchView: View {
                 }
                     .scaledToFit()
                     .frame(width: 120, height: 120)
-                    .padding(.top, 60)
+                    .padding(.top, Theme.Spacing.lg)
 
                 Spacer()
             }
@@ -71,8 +71,8 @@ struct LaunchView: View {
                         Image(systemName: "gearshape.fill")
                             .font(.title2)
                             .foregroundColor(.black)
-                            .padding(.top, 20)
-                            .padding(.trailing, 20)
+                            .padding(.top, Theme.Spacing.md)
+                            .padding(.trailing, Theme.Spacing.md)
                     }
                     Spacer()
                 }

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
@@ -15,21 +15,21 @@ struct SubmissionErrorView: View {
             Spacer()
             Image(systemName: "xmark.octagon.fill")
                 .font(.system(size: 64))
-                .foregroundColor(.red)
+                .foregroundColor(Theme.Colors.accent)
             Text("Submission Failed")
                 .font(.title)
                 .fontWeight(.semibold)
             Text("There was a problem sending your request. Please try again.")
                 .multilineTextAlignment(.center)
-                .padding(.horizontal)
+                .padding(.horizontal, Theme.Spacing.md)
 
             HStack(spacing: 20) {
                 Button(action: {
                     onDismiss()
                 }) {
                     Text("Cancel")
-                        .foregroundColor(.red)
-                        .padding()
+                        .foregroundColor(Theme.Colors.accent)
+                        .padding(Theme.Spacing.sm)
                         .frame(maxWidth: .infinity)
                         .background(Color(.systemGray6))
                         .cornerRadius(10)
@@ -39,18 +39,18 @@ struct SubmissionErrorView: View {
                     onDismiss()
                 }) {
                     Text("Try Again")
-                        .foregroundColor(.white)
-                        .padding()
+                        .foregroundColor(Theme.Colors.base)
+                        .padding(Theme.Spacing.sm)
                         .frame(maxWidth: .infinity)
-                        .background(Color.blue)
+                        .background(Theme.Colors.primary)
                         .cornerRadius(10)
                 }
             }
-            .padding(.top)
+            .padding(.top, Theme.Spacing.md)
 
             Spacer()
         }
-        .padding()
+        .padding(Theme.Spacing.md)
     }
 }
 

--- a/cueit-kiosk/README.md
+++ b/cueit-kiosk/README.md
@@ -10,3 +10,9 @@ When launched the kiosk registers itself with the backend using `/api/register-k
 3. Run the app on an iPad or simulator.
 
 If the build fails complaining about `TicketFormView` it means the project was previously incomplete. This repository now includes that view and the app should compile.
+
+### Theme
+
+SwiftUI views use color and spacing constants defined in `CueIT Kiosk/CueIT Kiosk/Theme.swift`.
+These values mirror the tokens in `../../design/theme.js` so the iPad app
+matches the web interfaces.

--- a/design/theme.js
+++ b/design/theme.js
@@ -1,0 +1,20 @@
+export const colors = {
+  primary: '#1D4ED8',
+  secondary: '#9333EA',
+  accent: '#F97316',
+  base: '#ffffff',
+  content: '#1f2937'
+};
+
+export const fonts = {
+  sans: ['Inter', 'system-ui', 'sans-serif']
+};
+
+export const spacing = {
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '1rem',
+  lg: '2rem'
+};
+
+export default { colors, fonts, spacing };


### PR DESCRIPTION
## Summary
- add `design/theme.js` with color, font, and spacing tokens
- integrate theme into `cueit-admin` Tailwind/DaisyUI config
- style the activation page with the shared tokens
- provide SwiftUI constants and apply them in views
- document theme usage in each README

## Testing
- `npm test --prefix cueit-backend` *(fails: mocha not found)*
- `npm test --prefix cueit-admin` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686603cc334c8333b45044497195d1ea