### PR TITLE
Add theming support

### DIFF
--- a/cueit-backend/README.md
+++ b/cueit-backend/README.md
@@ -5,7 +5,7 @@ An Express and SQLite API that receives help desk tickets and stores configurati
 ## Setup
 1. Run `npm install` in this folder.
 2. Create a `.env` file with your SMTP details and set `HELPDESK_EMAIL`.
-   Optional variables are `API_PORT` and `LOGO_URL`.
+   Optional variables are `API_PORT`, `LOGO_URL` and `PRIMARY_COLOR`.
 3. Start the server with `node index.js`.
 
 Kiosk devices register with `/api/register-kiosk` and can be activated through the admin UI.

--- a/cueit-backend/db.js
+++ b/cueit-backend/db.js
@@ -70,6 +70,7 @@ db.serialize(() => {
   const defaults = {
     logoUrl: process.env.LOGO_URL || '/logo.png',
     faviconUrl: process.env.FAVICON_URL || '/vite.svg',
+    primaryColor: process.env.PRIMARY_COLOR || '#0066CC',
     welcomeMessage: 'Welcome to the Help Desk',
     helpMessage: 'Need to report an issue?',
     adminPassword: 'admin'

--- a/cueit-backend/test/config.test.js
+++ b/cueit-backend/test/config.test.js
@@ -6,6 +6,7 @@ const app = global.app;
 const defaults = {
   logoUrl: '/logo.png',
   faviconUrl: '/vite.svg',
+  primaryColor: '#0066CC',
   welcomeMessage: 'Welcome to the Help Desk',
   helpMessage: 'Need to report an issue?',
   adminPassword: 'admin',

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/App/Theme.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/App/Theme.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        var hexString = hex
+        if hexString.hasPrefix("#") {
+            hexString.removeFirst()
+        }
+        var int: UInt64 = 0
+        Scanner(string: hexString).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+struct Theme {
+    static let titleFont = Font.system(size: 28, weight: .bold, design: .rounded)
+    static let bodyFont = Font.system(size: 18, weight: .regular, design: .rounded)
+    static let buttonFont = Font.system(size: 20, weight: .semibold, design: .rounded)
+    static let cornerRadius: CGFloat = 10
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
@@ -4,13 +4,18 @@ import SwiftUI
 struct AppConfig: Codable {
     var logoUrl: String
     var backgroundUrl: String?
+    var primaryColor: String?
     var welcomeMessage: String
     var helpMessage: String
     var adminPassword: String
 }
 
 class ConfigService: ObservableObject {
-    @Published var config: AppConfig = AppConfig(logoUrl: "/logo.png", backgroundUrl: nil, welcomeMessage: "Welcome", helpMessage: "Need help?", adminPassword: "admin")
+    @Published var config: AppConfig = AppConfig(logoUrl: "/logo.png", backgroundUrl: nil, primaryColor: nil, welcomeMessage: "Welcome", helpMessage: "Need help?", adminPassword: "admin")
+
+    var primaryColor: Color {
+        Color(hex: config.primaryColor ?? "#0066CC")
+    }
 
     func load() {
         if let data = UserDefaults.standard.data(forKey: "config"),

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
@@ -17,16 +17,17 @@ struct AdminLoginView: View {
         NavigationView {
             VStack(spacing: 20) {
                 Text("Admin Access")
-                    .font(.title).bold()
+                    .font(Theme.titleFont)
 
                 SecureField("Enter Password", text: $password)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .padding(.horizontal)
+                    .font(Theme.bodyFont)
 
                 if showError {
                     Text("Incorrect password")
                         .foregroundColor(.red)
-                        .font(.subheadline)
+                        .font(Theme.bodyFont)
                 }
 
                 Button("Login") {
@@ -37,6 +38,11 @@ struct AdminLoginView: View {
                     }
                 }
                 .padding()
+                .frame(maxWidth: .infinity)
+                .font(Theme.buttonFont)
+                .foregroundColor(.white)
+                .background(configService.primaryColor)
+                .cornerRadius(Theme.cornerRadius)
             }
             .padding()
             .navigationTitle("Admin Login")

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -40,12 +40,13 @@ struct LaunchView: View {
 
             VStack(spacing: 10) {
                 Text(configService.config.welcomeMessage)
-                    .font(.largeTitle).bold()
+                    .font(Theme.titleFont)
                 Text(configService.config.helpMessage)
-                    .font(.title2)
+                    .font(Theme.bodyFont)
                     .foregroundColor(.gray)
                 Text("Tap anywhere to begin")
                     .foregroundColor(.gray)
+                    .font(Theme.bodyFont)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -53,7 +54,7 @@ struct LaunchView: View {
             showForm = true
         }
         .fullScreenCover(isPresented: $showForm) {
-            TicketFormView()
+            TicketFormView(configService: configService)
         }
         .sheet(isPresented: $showAdmin) {
             AdminLoginView(configService: configService)
@@ -70,7 +71,7 @@ struct LaunchView: View {
                     }) {
                         Image(systemName: "gearshape.fill")
                             .font(.title2)
-                            .foregroundColor(.black)
+                            .foregroundColor(configService.primaryColor)
                             .padding(.top, 20)
                             .padding(.trailing, 20)
                     }

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SubmissionErrorView: View {
     var onDismiss: () -> Void
+    @ObservedObject var configService: ConfigService
 
     var body: some View {
         VStack(spacing: 20) {
@@ -17,8 +18,7 @@ struct SubmissionErrorView: View {
                 .font(.system(size: 64))
                 .foregroundColor(.red)
             Text("Submission Failed")
-                .font(.title)
-                .fontWeight(.semibold)
+                .font(Theme.titleFont)
             Text("There was a problem sending your request. Please try again.")
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
@@ -32,7 +32,7 @@ struct SubmissionErrorView: View {
                         .padding()
                         .frame(maxWidth: .infinity)
                         .background(Color(.systemGray6))
-                        .cornerRadius(10)
+                        .cornerRadius(Theme.cornerRadius)
                 }
 
                 Button(action: {
@@ -42,8 +42,8 @@ struct SubmissionErrorView: View {
                         .foregroundColor(.white)
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.blue)
-                        .cornerRadius(10)
+                        .background(configService.primaryColor)
+                        .cornerRadius(Theme.cornerRadius)
                 }
             }
             .padding(.top)
@@ -56,6 +56,7 @@ struct SubmissionErrorView: View {
 
 struct TicketFormView: View {
     @Environment(\.dismiss) var dismiss
+    @ObservedObject var configService: ConfigService
     @State private var name = ""
     @State private var email = ""
     @State private var title = ""
@@ -68,9 +69,13 @@ struct TicketFormView: View {
             Form {
                 Section(header: Text("Details")) {
                     TextField("Name", text: $name)
+                        .font(Theme.bodyFont)
                     TextField("Email", text: $email)
+                        .font(Theme.bodyFont)
                     TextField("Title", text: $title)
+                        .font(Theme.bodyFont)
                     TextField("System", text: $system)
+                        .font(Theme.bodyFont)
                     Picker("Urgency", selection: $urgency) {
                         Text("Low").tag("Low")
                         Text("Medium").tag("Medium")
@@ -81,6 +86,12 @@ struct TicketFormView: View {
                 Button("Submit") {
                     submit()
                 }
+                .font(Theme.buttonFont)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(8)
+                .background(configService.primaryColor)
+                .cornerRadius(Theme.cornerRadius)
             }
             .navigationTitle("New Ticket")
             .alert("Failed to submit", isPresented: $showError) {


### PR DESCRIPTION
## Summary
- add shared `Theme` with fonts and hex color helpers
- store a configurable `primaryColor` from `/api/config`
- use theme colors and fonts in SwiftUI views
- document `PRIMARY_COLOR` environment variable
- update tests for new config field

## Testing
- `npm install` *(passed)*
- `npm test` *(failed: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_6866041a66948333b12d553545ac800a