### PR TITLE
Add admin deletion endpoints and controls

### DIFF
--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo } from 'react';
 import axios from 'axios';
 import Navbar from './Navbar';
 import SettingsPanel from './SettingsPanel';
+import { useToast } from './Toast.jsx';
 import './App.css';
 
 const urgencyPriority = { Urgent: 3, High: 2, Medium: 1, Low: 0 };
@@ -16,6 +17,7 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [urgencyFilter, setUrgencyFilter] = useState('');
   const [systemFilter, setSystemFilter] = useState('');
+  const toast = useToast();
 
   const filteredLogs = useMemo(() => {
     const searchLower = search.toLowerCase();
@@ -51,11 +53,29 @@ function App() {
     logoUrl: import.meta.env.VITE_LOGO_URL,
     faviconUrl: import.meta.env.VITE_FAVICON_URL,
   });
+  const api = import.meta.env.VITE_API_URL;
+
+  const deleteLog = async (id) => {
+    try {
+      await axios.delete(`${api}/api/logs/${id}`);
+      setLogs((ls) => ls.filter((l) => l.id !== id));
+    } catch (err) {
+      toast('Failed to delete log', 'error');
+    }
+  };
+
+  const clearLogs = async () => {
+    try {
+      await axios.delete(`${api}/api/logs`);
+      setLogs([]);
+    } catch (err) {
+      toast('Failed to clear logs', 'error');
+    }
+  };
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const api = import.meta.env.VITE_API_URL;
         const [logsRes, configRes] = await Promise.all([
           axios.get(`${api}/api/logs`),
           axios.get(`${api}/api/config`)
@@ -132,6 +152,7 @@ function App() {
                       <option value="urgency">Sort by Urgency</option>
                       <option value="name">Sort by Name</option>
                     </select>
+                    <button onClick={clearLogs} className="px-2 py-1 bg-red-600 rounded text-xs">Clear Logs</button>
                   </div>
                 </div>
               </div>
@@ -147,6 +168,7 @@ function App() {
                       <th className="px-4 py-2 text-left whitespace-nowrap">Urgency</th>
                       <th className="px-4 py-2 text-left whitespace-nowrap">Email Status</th>
                       <th className="px-4 py-2 text-left whitespace-nowrap">Submitted At</th>
+                      <th className="px-4 py-2 text-left"></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -175,6 +197,9 @@ function App() {
                           </span>
                         </td>
                         <td className="px-4 py-2 text-left text-xs">{new Date(log.timestamp).toLocaleString()}</td>
+                        <td className="px-4 py-2 text-left">
+                          <button onClick={() => deleteLog(log.id)} className="text-red-600 text-xs hover:underline">Delete</button>
+                        </td>
                       </tr>
                     ))}
                   </tbody>

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -51,6 +51,24 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
     }
   };
 
+  const deleteKiosk = async (id) => {
+    try {
+      await axios.delete(`${api}/api/kiosks/${id}`);
+      setKiosks((ks) => ks.filter((x) => x.id !== id));
+    } catch (err) {
+      toast('Failed to delete kiosk', 'error');
+    }
+  };
+
+  const clearKiosks = async () => {
+    try {
+      await axios.delete(`${api}/api/kiosks`);
+      setKiosks([]);
+    } catch (err) {
+      toast('Failed to clear kiosks', 'error');
+    }
+  };
+
   return (
     <div className={`fixed inset-0 bg-black/50 z-50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}>
       <div className={`absolute right-0 top-0 bottom-0 w-96 bg-gray-800 text-white p-6 transform transition-all duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}>
@@ -133,6 +151,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
         )}
         {tab === 'kiosks' && (
           <div className="overflow-y-auto text-sm h-full">
+            <button onClick={clearKiosks} className="mb-2 px-2 py-1 bg-red-600 rounded">Clear Kiosks</button>
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left">
@@ -142,6 +161,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
                   <th className="pb-2">Logo URL</th>
                   <th className="pb-2">Background</th>
                   <th className="pb-2">Active</th>
+                  <th className="pb-2"></th>
                   <th className="pb-2"></th>
                 </tr>
               </thead>
@@ -177,6 +197,9 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
                     </td>
                     <td className="py-1 pl-2">
                       <button onClick={() => saveKiosk(k)} className="px-2 py-1 rounded text-xs bg-blue-600">Save</button>
+                    </td>
+                    <td className="py-1 pl-2">
+                      <button onClick={() => deleteKiosk(k.id)} className="px-2 py-1 rounded text-xs bg-red-600">Delete</button>
                     </td>
                   </tr>
                 ))}

--- a/cueit-backend/README.md
+++ b/cueit-backend/README.md
@@ -28,6 +28,8 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
 ### Logs and Configuration
 
 - `GET /api/logs` – return all ticket logs sorted by timestamp.
+- `DELETE /api/logs/:id` – delete a log entry by numeric id.
+- `DELETE /api/logs` – remove all log entries.
 - `GET /api/config` – return configuration key/value pairs.
 - `PUT /api/config` – insert or update configuration values.
 
@@ -38,6 +40,8 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
 - `PUT /api/kiosks/:id` – update kiosk branding and active state.
 - `GET /api/kiosks` – list all kiosks.
 - `PUT /api/kiosks/:id/active` – toggle its active flag.
+- `DELETE /api/kiosks/:id` – delete a kiosk by id.
+- `DELETE /api/kiosks` – remove all kiosks.
 
 ### Database Schema
 

--- a/cueit-backend/db.js
+++ b/cueit-backend/db.js
@@ -81,4 +81,21 @@ db.serialize(() => {
   stmt.finalize();
 });
 
+// helpers for deleting records
+db.deleteLog = (id, cb) => {
+  db.run(`DELETE FROM logs WHERE id=?`, [id], cb);
+};
+
+db.deleteAllLogs = (cb) => {
+  db.run(`DELETE FROM logs`, cb);
+};
+
+db.deleteKiosk = (id, cb) => {
+  db.run(`DELETE FROM kiosks WHERE id=?`, [id], cb);
+};
+
+db.deleteAllKiosks = (cb) => {
+  db.run(`DELETE FROM kiosks`, cb);
+};
+
 module.exports = db;

--- a/cueit-backend/index.js
+++ b/cueit-backend/index.js
@@ -78,6 +78,20 @@ app.get("/api/logs", (req, res) => {
   });
 });
 
+app.delete("/api/logs/:id", (req, res) => {
+  db.deleteLog(req.params.id, (err) => {
+    if (err) return res.status(500).json({ error: "DB error" });
+    res.json({ message: "deleted" });
+  });
+});
+
+app.delete("/api/logs", (req, res) => {
+  db.deleteAllLogs((err) => {
+    if (err) return res.status(500).json({ error: "DB error" });
+    res.json({ message: "cleared" });
+  });
+});
+
 app.get("/api/config", (req, res) => {
   db.all(`SELECT key, value FROM config`, (err, rows) => {
     if (err) return res.status(500).json({ error: "DB error" });
@@ -140,6 +154,20 @@ app.get("/api/kiosks", (req, res) => {
   db.all(`SELECT * FROM kiosks`, (err, rows) => {
     if (err) return res.status(500).json({ error: "DB error" });
     res.json(rows);
+  });
+});
+
+app.delete("/api/kiosks/:id", (req, res) => {
+  db.deleteKiosk(req.params.id, (err) => {
+    if (err) return res.status(500).json({ error: "DB error" });
+    res.json({ message: "deleted" });
+  });
+});
+
+app.delete("/api/kiosks", (req, res) => {
+  db.deleteAllKiosks((err) => {
+    if (err) return res.status(500).json({ error: "DB error" });
+    res.json({ message: "cleared" });
   });
 });
 


### PR DESCRIPTION
## Summary
- create helper functions in `db.js` to remove log and kiosk entries
- support deleting logs and kiosks in the backend API
- document the new endpoints in the backend README
- expose buttons in the admin UI to clear and delete logs and kiosks

## Testing
- `npm test --silent` in `cueit-backend`
- `npm test --silent` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_6866063e2668833397b9ac93bcddf930