### PR TITLE
Add kiosk activation polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ admin UI or by visiting the separate activation page provided by the
 fetches its configuration from `/api/kiosks/:id`; if `active` is `0` it shows an
 activation required message instead of the ticket form.
 
+To remotely disable a kiosk open the **Kiosks** tab in the admin UI and toggle
+the active switch to the off position. You can also send a `PUT` request to
+`/api/kiosks/{id}/active` with `{ "active": false }` to deactivate a kiosk via
+the API. The kiosk will stop displaying the ticket form once its next activation
+check detects the change.
+
 ## Components
 
 - **cueit-backend** – Express API with an SQLite database. It exposes endpoints

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/ActivationErrorView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/ActivationErrorView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ActivationErrorView: View {
+    var onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "xmark.octagon.fill")
+                .font(.system(size: 64))
+                .foregroundColor(Theme.Colors.accent)
+            Text("Activation Error")
+                .font(.title)
+                .fontWeight(.semibold)
+            Text("Unable to verify kiosk status. Check your connection and try again.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.md)
+            Button("Retry") {
+                onRetry()
+            }
+            .padding(Theme.Spacing.sm)
+            .background(Theme.Colors.primary)
+            .foregroundColor(Theme.Colors.base)
+            .cornerRadius(8)
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.Colors.base.ignoresSafeArea())
+    }
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -11,41 +11,49 @@ struct LaunchView: View {
     @State private var showForm = false
     @State private var showAdmin = false
     @StateObject private var configService = ConfigService()
+    @StateObject private var kioskService = KioskService.shared
 
     var body: some View {
         ZStack {
-            if let bg = configService.config.backgroundUrl,
-               let url = URL(string: bg) {
-                AsyncImage(url: url) { img in
-                    img.resizable().scaledToFill()
-                } placeholder: {
-                    Theme.Colors.base
+            switch kioskService.state {
+            case .inactive:
+                PendingActivationView()
+            case .error:
+                ActivationErrorView { kioskService.checkActive() }
+            default:
+                if let bg = configService.config.backgroundUrl,
+                   let url = URL(string: bg) {
+                    AsyncImage(url: url) { img in
+                        img.resizable().scaledToFill()
+                    } placeholder: {
+                        Theme.Colors.base
+                    }
+                    .ignoresSafeArea()
+                } else {
+                    Theme.Colors.base.ignoresSafeArea()
                 }
-                .ignoresSafeArea()
-            } else {
-                Theme.Colors.base.ignoresSafeArea()
-            }
-            VStack {
-                AsyncImage(url: URL(string: configService.config.logoUrl)) { img in
-                    img.resizable()
-                } placeholder: {
-                    Image("logo").resizable()
+                VStack {
+                    AsyncImage(url: URL(string: configService.config.logoUrl)) { img in
+                        img.resizable()
+                    } placeholder: {
+                        Image("logo").resizable()
+                    }
+                        .scaledToFit()
+                        .frame(width: 120, height: 120)
+                        .padding(.top, Theme.Spacing.lg)
+
+                    Spacer()
                 }
-                    .scaledToFit()
-                    .frame(width: 120, height: 120)
-                    .padding(.top, Theme.Spacing.lg)
 
-                Spacer()
-            }
-
-            VStack(spacing: 10) {
-                Text(configService.config.welcomeMessage)
-                    .font(.largeTitle).bold()
-                Text(configService.config.helpMessage)
-                    .font(.title2)
-                    .foregroundColor(.gray)
-                Text("Tap anywhere to begin")
-                    .foregroundColor(.gray)
+                VStack(spacing: 10) {
+                    Text(configService.config.welcomeMessage)
+                        .font(.largeTitle).bold()
+                    Text(configService.config.helpMessage)
+                        .font(.title2)
+                        .foregroundColor(.gray)
+                    Text("Tap anywhere to begin")
+                        .foregroundColor(.gray)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/PendingActivationView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/PendingActivationView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct PendingActivationView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "pause.circle.fill")
+                .font(.system(size: 64))
+                .foregroundColor(Theme.Colors.accent)
+            Text("Pending Activation")
+                .font(.title)
+                .fontWeight(.semibold)
+            Text("This kiosk is not active yet. Please contact IT to enable it.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.md)
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.Colors.base.ignoresSafeArea())
+    }
+}


### PR DESCRIPTION
## Summary
- poll `/api/kiosks/{id}` for activation status
- show `PendingActivationView` or `ActivationErrorView` based on status
- update LaunchView to react to activation state
- document how to disable a kiosk remotely

## Testing
- `npm test` in `cueit-admin`
- `npm test` in `cueit-backend` *(fails: invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_686608580e1483338968c5ed884a054c