### PR TITLE
Implement API connection indicator

### DIFF
--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -7,6 +7,7 @@ export default function Navbar({
   showSearch,
   setShowSearch,
   openSettings,
+  apiConnected,
 }) {
   const [showMenu, setShowMenu] = useState(false);
   return (
@@ -15,6 +16,10 @@ export default function Navbar({
         <div className="flex items-center gap-3">
           {logo && <img src={logo} alt="Logo" className="h-[60px] w-[60px] object-contain" />}
           <span className="text-2xl font-bold tracking-tight">CueIT Admin</span>
+          <span
+            className={`ml-2 h-3 w-3 rounded-full ${apiConnected ? 'bg-green-500' : 'bg-red-500'}`}
+            aria-label={apiConnected ? 'API connected' : 'API disconnected'}
+          />
         </div>
         <div className="flex items-center gap-4 pr-2">
           <div className="relative">

--- a/cueit-backend/index.js
+++ b/cueit-backend/index.js
@@ -223,6 +223,10 @@ app.delete("/api/users/:id", (req, res) => {
   });
 });
 
+app.get("/api/health", (req, res) => {
+  res.json({ ok: true });
+});
+
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`✅ CueIT Backend running at http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint on the backend
- poll the API from the admin app to check availability
- show connection indicator in the navbar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660c84ae8483338c5e139a222c09b7