### PR TITLE
Add start-all scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ page and SwiftUI kiosk app.
 - npm
 - sqlite3
 - [Mailpit](https://github.com/axllent/mailpit) (SMTP testing server)
+- Xcode on macOS if you plan to build the SwiftUI kiosk
 
 ## Setup
 
@@ -59,6 +60,25 @@ Configuration values are stored in the same database and can be edited from the 
 ```bash
 npx ngrok http $SLACK_PORT
 ```
+
+### Running All Services
+
+Scripts are provided to launch the API, admin UI, activation page and Slack
+service together using `concurrently`.
+
+#### macOS / Linux
+
+```bash
+./start-all.sh
+```
+
+#### Windows
+
+```powershell
+./start-all.ps1
+```
+
+The SwiftUI kiosk can only be built and run on macOS with Xcode installed.
 
 ## Testing the API
 

--- a/start-all.ps1
+++ b/start-all.ps1
@@ -1,0 +1,6 @@
+npx concurrently -k -n api,admin,activate,slack `
+  "node cueit-api/index.js" `
+  "npm --prefix cueit-admin run dev" `
+  "npm --prefix cueit-activate run dev" `
+  "node cueit-slack/index.js"
+

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+npx concurrently -k -n api,admin,activate,slack \
+  "node cueit-api/index.js" \
+  "npm --prefix cueit-admin run dev" \
+  "npm --prefix cueit-activate run dev" \
+  "node cueit-slack/index.js"
+


### PR DESCRIPTION
## Summary
- add `start-all.sh` and PowerShell version with concurrently
- document start-all usage and OS requirements in README

## Testing
- `npm test --prefix cueit-backend`
- `npm test --prefix cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_6866207047a483339439183252337df3