### PR TITLE
Improve Slack setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The backend stores ticket logs in a local SQLite database (`cueit-backend/log.sq
 Configuration values are stored in the same database and can be edited from the admin UI.
 
 ### Slack Service
-1. Create a Slack app and define a `/new-ticket` slash command. Set its request URL to this service.
+1. Create a Slack app following [Slack's app setup guide](https://api.slack.com/apps) and add a `/new-ticket` slash command (see [Slash commands documentation](https://api.slack.com/interactivity/slash-commands)). Set its request URL to this service.
 2. Navigate to `cueit-slack` and run `npm install`.
 3. Create a `.env` file with:
    - `SLACK_SIGNING_SECRET`

--- a/cueit-slack/README.md
+++ b/cueit-slack/README.md
@@ -3,13 +3,14 @@
 Slack slash command integration that lets users submit tickets directly from Slack.
 
 ## Setup
-1. Run `npm install` in this directory.
-2. Create a `.env` file with the following variables:
+1. Create a Slack app (see [Slack's app setup docs](https://api.slack.com/apps)) and add a `/new-ticket` slash command. The [slash command guide](https://api.slack.com/interactivity/slash-commands) explains how to configure the command and obtain your tokens.
+2. Run `npm install` in this directory.
+3. Create a `.env` file with the following variables:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
    - `BACKEND_URL`
    - optional `SLACK_PORT` (defaults to `3001`)
-3. Start the service with `node index.js`.
+4. Start the service with `node index.js`.
 
 ## Local Testing
 Slack slash commands require a public HTTPS endpoint. While developing you can expose your local service using [ngrok](https://ngrok.com/):


### PR DESCRIPTION
## Summary
- clarify Slack setup instructions in main README
- detail Slack app creation steps in `cueit-slack` README

## Testing
- `npm test` in `cueit-backend`
- `npm test` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_6866209d9d148333b2b62291df818c45