### PR TITLE
Replace FontAwesome with Heroicons

### DIFF
--- a/cueit-admin/README.md
+++ b/cueit-admin/README.md
@@ -8,7 +8,7 @@ React based interface for viewing help desk tickets and managing system settings
 3. Start the dev server with `npm run dev`.
 
 The admin UI lets you search tickets, edit configuration values, activate kiosk devices and manage users from the new **Users** tab in Settings.
-Font Awesome is loaded via CDN in `index.html` to provide icons throughout the interface.
+Icons come from [Heroicons](https://github.com/tailwindlabs/heroicons) and are imported as React components.
 
 ### Theme
 

--- a/cueit-admin/package-lock.json
+++ b/cueit-admin/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cueit-admin",
       "version": "0.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@heroicons/react": "^2.0.18",
         "@tailwindcss/vite": "^4.1.11",
         "axios": "^1.10.0",
         "daisyui": "^5.0.43",
@@ -2670,13 +2670,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/cueit-admin/package.json
+++ b/cueit-admin/package.json
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.7.2",
+    "@heroicons/react": "^2.0.18",
     "@tailwindcss/vite": "^4.1.11",
     "axios": "^1.10.0",
     "daisyui": "^5.0.43",

--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -1,4 +1,10 @@
 import React, { useState } from 'react';
+import {
+  Cog6ToothIcon,
+  InformationCircleIcon,
+  MagnifyingGlassIcon,
+  QuestionMarkCircleIcon,
+} from '@heroicons/react/24/outline';
 
 export default function Navbar({
   logo,
@@ -28,7 +34,7 @@ export default function Navbar({
               className="p-2 hover:text-gray-200"
               aria-label="Settings"
             >
-              <i className="fa-solid fa-gear" />
+              <Cog6ToothIcon className="h-5 w-5" />
             </button>
             {showMenu && (
               <div className="absolute right-0 mt-2 w-40 bg-white text-black rounded shadow-md py-1 space-y-1">
@@ -39,7 +45,7 @@ export default function Navbar({
                   }}
                   className="block w-full text-left px-4 py-2 flex items-center gap-2 hover:bg-gray-100"
                 >
-                  <i className="fa-solid fa-gear" />
+                  <Cog6ToothIcon className="h-5 w-5" />
                   Settings
                 </button>
                 <button
@@ -49,7 +55,7 @@ export default function Navbar({
                   }}
                   className="block w-full text-left px-4 py-2 flex items-center gap-2 hover:bg-gray-100"
                 >
-                  <i className="fa-solid fa-circle-info" />
+                  <InformationCircleIcon className="h-5 w-5" />
                   About
                 </button>
                 <button
@@ -59,7 +65,7 @@ export default function Navbar({
                   }}
                   className="block w-full text-left px-4 py-2 flex items-center gap-2 hover:bg-gray-100"
                 >
-                  <i className="fa-solid fa-question-circle" />
+                  <QuestionMarkCircleIcon className="h-5 w-5" />
                   Help
                 </button>
               </div>
@@ -71,7 +77,7 @@ export default function Navbar({
               className="p-2 hover:text-gray-200"
               aria-label="Toggle Search"
             >
-              <i className="fa-solid fa-magnifying-glass" />
+              <MagnifyingGlassIcon className="h-5 w-5" />
             </button>
             <div className="relative">
               <input

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import UsersPanel from './UsersPanel.jsx';
 import { useToast } from './Toast.jsx';
@@ -72,7 +73,9 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
   return (
     <div className={`fixed inset-0 bg-black/50 z-50 transition-opacity ${open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}>
       <div className={`absolute right-0 top-0 bottom-0 w-96 bg-gray-800 text-white p-6 transform transition-all duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}>
-        <button onClick={onClose} className="mb-4 text-right w-full hover:text-gray-300">✖</button>
+        <button onClick={onClose} className="mb-4 text-right w-full hover:text-gray-300">
+          <XMarkIcon className="w-5 h-5 inline" />
+        </button>
         <div className="flex mb-4 border-b border-gray-700 text-sm">
           <button className={`mr-4 pb-2 ${tab === 'general' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('general')}>General</button>
           <button className={`mr-4 pb-2 ${tab === 'kiosks' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('kiosks')}>Kiosks</button>

--- a/cueit-admin/src/main.jsx
+++ b/cueit-admin/src/main.jsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import '@fortawesome/fontawesome-free/css/all.min.css'
 import App from './App.jsx'
 import { ToastProvider } from './Toast.jsx'
 


### PR DESCRIPTION
## Summary
- scaffold modern icon library by adding `@heroicons/react`
- remove FontAwesome import
- update Navbar and SettingsPanel to use Heroicons
- update admin README to reference the new icon library

## Testing
- `npm run lint` (fails: many existing lint errors)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866226045cc833397adfbd2363709c9