### PR TITLE
Link activation page back to admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ admin UI or by visiting the separate activation page provided by the
 `PUT /api/kiosks/:id/active` to update the flag. The iPad app periodically
 fetches its configuration from `/api/kiosks/:id`; if `active` is `0` it shows an
 activation required message instead of the ticket form.
+When `VITE_ADMIN_URL` is set, the activation page shows a link back to the admin
+UI for convenience.
 
 To remotely disable a kiosk open the **Kiosks** tab in the admin UI and toggle
 the active switch to the off position. You can also send a `PUT` request to
@@ -151,10 +153,12 @@ Each app relies on a few environment variables:
 - `VITE_API_URL` – base URL of the backend API.
 - `VITE_LOGO_URL` – default logo shown before configuration is loaded.
 - `VITE_FAVICON_URL` – default favicon for the page.
+- `VITE_ACTIVATE_URL` – optional URL of the activation page for linking.
 
 ### Activation App
 
 - `VITE_API_URL` – backend URL used for the activation request.
+- `VITE_ADMIN_URL` – optional link back to the admin UI shown on the page.
 
 ### Slack Service
 

--- a/cueit-activate/.env.example
+++ b/cueit-activate/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3000
+VITE_ADMIN_URL=http://localhost:5173

--- a/cueit-activate/README.md
+++ b/cueit-activate/README.md
@@ -4,7 +4,8 @@ A minimal React page for activating kiosks.
 
 ## Setup
 1. Run `npm install` in this folder.
-2. Create a `.env` with `VITE_API_URL` pointing to the backend.
+2. Create a `.env` with `VITE_API_URL` pointing to the backend. Optionally set
+   `VITE_ADMIN_URL` to the admin interface so a link appears on the page.
 3. Start the dev server with `npm run dev`.
 
 ### Theme

--- a/cueit-activate/src/App.jsx
+++ b/cueit-activate/src/App.jsx
@@ -5,6 +5,7 @@ import theme from '../../design/theme.js';
 export default function App() {
   const [kioskId, setKioskId] = useState('');
   const [message, setMessage] = useState('');
+  const adminUrl = import.meta.env.VITE_ADMIN_URL;
 
   const activate = async () => {
     if (!kioskId) return;
@@ -55,6 +56,18 @@ export default function App() {
         Activate
       </button>
       {message && <p style={{ marginTop: theme.spacing.md }}>{message}</p>}
+      {adminUrl && (
+        <a
+          href={adminUrl}
+          style={{
+            marginTop: theme.spacing.md,
+            color: theme.colors.primary,
+            textDecoration: 'underline',
+          }}
+        >
+          Go to Admin UI
+        </a>
+      )}
     </div>
   );
 }

--- a/cueit-admin/.env.example
+++ b/cueit-admin/.env.example
@@ -1,3 +1,4 @@
 VITE_LOGO_URL=/logo.png
 VITE_API_URL=http://localhost:3000
 VITE_FAVICON_URL=/vite.svg
+VITE_ACTIVATE_URL=http://localhost:5174

--- a/cueit-admin/README.md
+++ b/cueit-admin/README.md
@@ -5,6 +5,8 @@ React based interface for viewing help desk tickets and managing system settings
 ## Setup
 1. Run `npm install` in this directory.
 2. Create a `.env` file with `VITE_API_URL` and optional `VITE_LOGO_URL`.
+   You can also set `VITE_ACTIVATE_URL` to display a link to the kiosk
+   activation page.
 3. Start the dev server with `npm run dev`.
 
 The admin UI lets you search tickets, edit configuration values, activate kiosk devices and manage users from the new **Users** tab in Settings.

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -8,6 +8,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
   const [tab, setTab] = useState('general');
   const [kiosks, setKiosks] = useState([]);
   const api = import.meta.env.VITE_API_URL;
+  const activateUrl = import.meta.env.VITE_ACTIVATE_URL;
   const toast = useToast();
 
   useEffect(() => {
@@ -154,7 +155,14 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
         )}
         {tab === 'kiosks' && (
           <div className="overflow-y-auto text-sm h-full">
-            <button onClick={clearKiosks} className="mb-2 px-2 py-1 bg-red-600 rounded">Clear Kiosks</button>
+            <div className="flex items-center justify-between mb-2">
+              <button onClick={clearKiosks} className="px-2 py-1 bg-red-600 rounded">Clear Kiosks</button>
+              {activateUrl && (
+                <a href={activateUrl} target="_blank" rel="noopener" className="text-primary underline text-xs">
+                  Open Activation Page
+                </a>
+              )}
+            </div>
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left">


### PR DESCRIPTION
## Summary
- add optional `VITE_ADMIN_URL` env variable for activation page
- show link to admin UI from activation interface
- allow admin UI to link out to the activation page via `VITE_ACTIVATE_URL`
- document new variables in READMEs
- include sample env files

## Testing
- `npm --prefix cueit-admin run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix cueit-admin test`
- `npm --prefix cueit-activate test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686623d394508333a75a67345c0ce4d4