### PR TITLE
Fix start-all scripts for new backend location

### DIFF
--- a/start-all.ps1
+++ b/start-all.ps1
@@ -1,5 +1,5 @@
 npx concurrently -k -n api,admin,activate,slack `
-  "node cueit-api/index.js" `
+  "node cueit-backend/index.js" `
   "npm --prefix cueit-admin run dev" `
   "npm --prefix cueit-activate run dev" `
   "node cueit-slack/index.js"

--- a/start-all.sh
+++ b/start-all.sh
@@ -2,7 +2,7 @@
 set -e
 
 npx concurrently -k -n api,admin,activate,slack \
-  "node cueit-api/index.js" \
+  "node cueit-backend/index.js" \
   "npm --prefix cueit-admin run dev" \
   "npm --prefix cueit-activate run dev" \
   "node cueit-slack/index.js"


### PR DESCRIPTION
## Summary
- update `start-all.sh` and `start-all.ps1` to launch `cueit-backend/index.js`

## Testing
- `npm run lint` in `cueit-admin` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `cueit-admin` *(fails: jest not found)*
- `npm test` in `cueit-backend` *(fails: mocha not found)*
- `./start-all.sh` *(fails: concurrently not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686626e279048333a48f10c5725ba223