### PR TITLE
Implement base API URL setting

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>API_BASE_URL</key>
+    <string>http://localhost:3000</string>
+</dict>
+</plist>

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/APIConfig.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/APIConfig.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum APIConfig {
+    static var baseURL: String {
+        if let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String {
+            return url
+        }
+        return "http://localhost:3000"
+    }
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
@@ -17,7 +17,7 @@ class ConfigService: ObservableObject {
            let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) {
             self.config = cfg
         }
-        guard let url = URL(string: "http://localhost:3000/api/config") else { return }
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/config") else { return }
         URLSession.shared.dataTask(with: url) { data, _, _ in
             if let data = data, let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) {
                 DispatchQueue.main.async {
@@ -31,7 +31,7 @@ class ConfigService: ObservableObject {
 
         // kiosk specific overrides
         if let kioskId = UserDefaults.standard.string(forKey: "kioskId"),
-           let kurl = URL(string: "http://localhost:3000/api/kiosks/\(kioskId)") {
+           let kurl = URL(string: "\(APIConfig.baseURL)/api/kiosks/\(kioskId)") {
             struct KioskConfig: Codable { var logoUrl: String?; var bgUrl: String? }
             URLSession.shared.dataTask(with: kurl) { data, _, _ in
                 if let data = data, let row = try? JSONDecoder().decode(KioskConfig.self, from: data) {

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
@@ -27,7 +27,7 @@ class KioskService: ObservableObject {
     }()
 
     func register(version: String) {
-        guard let url = URL(string: "http://localhost:3000/api/register-kiosk") else { return }
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/register-kiosk") else { return }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -37,7 +37,7 @@ class KioskService: ObservableObject {
     }
 
     func checkActive() {
-        guard let url = URL(string: "http://localhost:3000/api/kiosks/\(id)") else { return }
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/kiosks/\(id)") else { return }
         struct KioskRow: Codable { var active: Int }
         URLSession.shared.dataTask(with: url) { data, _, _ in
             DispatchQueue.main.async {

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/TicketFormView.swift
@@ -90,7 +90,7 @@ struct TicketFormView: View {
     }
 
     func submit() {
-        guard let url = URL(string: "http://localhost:3000/submit-ticket") else { return }
+        guard let url = URL(string: "\(APIConfig.baseURL)/submit-ticket") else { return }
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
## Summary
- add API base URL to Info.plist
- read API_BASE_URL through new `APIConfig` helper
- use `APIConfig.baseURL` in ConfigService, KioskService and TicketFormView

## Testing
- `npm run lint` within `cueit-admin` *(fails: 37 errors, 3 warnings)*
- `npm test` within `cueit-admin`
- `npm test` within `cueit-backend`


------
https://chatgpt.com/codex/tasks/task_e_686627cda7008333a43a25dd7e7dfed4