### PR TITLE
Rename BACKEND_URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Configuration values are stored in the same database and can be edited from the 
 3. Create a `.env` file with:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
-   - `BACKEND_URL`
+   - `API_URL`
    - optional `SLACK_PORT` (defaults to `3001`)
  4. Start the service with `node index.js`. It listens on `SLACK_PORT`.
  5. For local testing expose the port with `ngrok` and use the HTTPS URL in your Slack command:
@@ -165,7 +165,7 @@ Each app relies on a few environment variables:
 - `SLACK_SIGNING_SECRET` – Slack app signing secret.
 - `SLACK_BOT_TOKEN` – bot token with permissions to open modals and post
   messages.
-- `BACKEND_URL` – base URL of the backend API for ticket submission.
+- `API_URL` – base URL of the backend API for ticket submission.
 - Optional: `SLACK_PORT` (default `3001`).
 
 ## Future Improvements

--- a/cueit-slack/.env.example
+++ b/cueit-slack/.env.example
@@ -1,4 +1,4 @@
 SLACK_SIGNING_SECRET=your-secret
 SLACK_BOT_TOKEN=xoxb-your-token
-BACKEND_URL=http://localhost:3000
+API_URL=http://localhost:3000
 SLACK_PORT=3001

--- a/cueit-slack/README.md
+++ b/cueit-slack/README.md
@@ -8,7 +8,7 @@ Slack slash command integration that lets users submit tickets directly from Sla
 3. Create a `.env` file with the following variables:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
-   - `BACKEND_URL`
+   - `API_URL`
    - optional `SLACK_PORT` (defaults to `3001`)
 4. Start the service with `node index.js`.
 

--- a/cueit-slack/index.js
+++ b/cueit-slack/index.js
@@ -88,7 +88,7 @@ app.view('ticket_submit', async ({ ack, body, view, client }) => {
   };
 
   try {
-    const res = await axios.post(`${process.env.BACKEND_URL}/submit-ticket`, payload);
+    const res = await axios.post(`${process.env.API_URL}/submit-ticket`, payload);
     const { ticketId, emailStatus } = res.data;
     await client.chat.postMessage({
       channel: body.user.id,


### PR DESCRIPTION
## Summary
- update Slack service to use `API_URL`
- update Slack docs and example env file
- change root README Slack instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68662b75670483338db2c7c1402bd0c2