### PR TITLE
Update API naming and start scripts

### DIFF
--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -286,7 +286,7 @@ app.get("/api/health", (req, res) => {
 
 if (require.main === module) {
   app.listen(PORT, () => {
-    console.log(`✅ CueIT Backend running at http://localhost:${PORT}`);
+    console.log(`✅ CueIT API running at http://localhost:${PORT}`);
   });
 }
 

--- a/start-all.ps1
+++ b/start-all.ps1
@@ -1,5 +1,5 @@
 npx concurrently -k -n api,admin,activate,slack `
-  "node cueit-backend/index.js" `
+  "node cueit-api/index.js" `
   "npm --prefix cueit-admin run dev" `
   "npm --prefix cueit-activate run dev" `
   "node cueit-slack/index.js"

--- a/start-all.sh
+++ b/start-all.sh
@@ -2,7 +2,7 @@
 set -e
 
 npx concurrently -k -n api,admin,activate,slack \
-  "node cueit-backend/index.js" \
+  "node cueit-api/index.js" \
   "npm --prefix cueit-admin run dev" \
   "npm --prefix cueit-activate run dev" \
   "node cueit-slack/index.js"


### PR DESCRIPTION
## Summary
- update console message to "CueIT API"
- point start-all scripts at cueit-api directory

## Testing
- `npm test` in `cueit-api`

------
https://chatgpt.com/codex/tasks/task_e_68662b68437083339b11d996c9b2c6c8