### PR TITLE
Migrate cueit-api to ES modules

### DIFF
--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -1,6 +1,7 @@
 // db.js
-const sqlite3 = require("sqlite3").verbose();
-const bcrypt = require('bcryptjs');
+import sqlite3pkg from 'sqlite3';
+import bcrypt from 'bcryptjs';
+const sqlite3 = sqlite3pkg.verbose();
 const db = new sqlite3.Database("log.sqlite");
 
 db.serialize(() => {
@@ -99,4 +100,4 @@ db.deleteAllKiosks = (cb) => {
   db.run(`DELETE FROM kiosks`, cb);
 };
 
-module.exports = db;
+export default db;

--- a/cueit-api/events.js
+++ b/cueit-api/events.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+import { EventEmitter } from 'events';
 
 // Singleton event bus used by the backend to broadcast state changes
-module.exports = new EventEmitter();
+export default new EventEmitter();

--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -1,12 +1,15 @@
-require("dotenv").config();
-const express = require("express");
-const cors = require("cors");
-const nodemailer = require("nodemailer");
-const axios = require("axios");
-const bcrypt = require('bcryptjs');
-const db = require("./db");
-const { v4: uuidv4 } = require("uuid");
-const events = require("./events");
+import dotenv from 'dotenv';
+import express from 'express';
+import cors from 'cors';
+import nodemailer from 'nodemailer';
+import axios from 'axios';
+import bcrypt from 'bcryptjs';
+import db from './db.js';
+import { v4 as uuidv4 } from 'uuid';
+import events from './events.js';
+import { fileURLToPath } from 'url';
+
+dotenv.config();
 
 const app = express();
 app.use(cors());
@@ -284,10 +287,11 @@ app.get("/api/health", (req, res) => {
   res.json({ ok: true });
 });
 
-if (require.main === module) {
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
   app.listen(PORT, () => {
     console.log(`✅ CueIT API running at http://localhost:${PORT}`);
   });
 }
 
-module.exports = app;
+export default app;

--- a/cueit-api/package.json
+++ b/cueit-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cueit-api",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "mocha"

--- a/cueit-api/test/00_setup.js
+++ b/cueit-api/test/00_setup.js
@@ -1,4 +1,5 @@
-const nodemailer = require('nodemailer');
+import nodemailer from 'nodemailer';
+let app;
 let sendBehavior = async () => {};
 const originalCreate = nodemailer.createTransport;
 
@@ -6,11 +7,11 @@ nodemailer.createTransport = () => ({
   sendMail: (opts) => sendBehavior(opts),
 });
 
-const app = require('../index');
+const mod = await import('../index.js');
+app = mod.default;
+globalThis.app = app;
 
-global.app = app;
-
-global.setSendBehavior = (fn) => {
+globalThis.setSendBehavior = (fn) => {
   sendBehavior = fn;
 };
 

--- a/cueit-api/test/config.test.js
+++ b/cueit-api/test/config.test.js
@@ -1,8 +1,8 @@
-const request = require('supertest');
-const assert = require('assert');
-const db = require('../db');
-const bcrypt = require('bcryptjs');
-const app = global.app;
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+import bcrypt from 'bcryptjs';
+const app = globalThis.app;
 
 const defaults = {
   logoUrl: '/logo.png',

--- a/cueit-api/test/kiosk.test.js
+++ b/cueit-api/test/kiosk.test.js
@@ -1,7 +1,7 @@
-const request = require('supertest');
-const assert = require('assert');
-const app = global.app || require('../index');
-const db = require('../db');
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+const app = globalThis.app || (await import('../index.js')).default;
 
 beforeEach((done) => {
   db.run('DELETE FROM kiosks', done);

--- a/cueit-api/test/submit-ticket.test.js
+++ b/cueit-api/test/submit-ticket.test.js
@@ -1,7 +1,8 @@
-const request = require('supertest');
-const assert = require('assert');
-const db = require('../db');
-const app = global.app;
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+import bcrypt from 'bcryptjs';
+const app = globalThis.app;
 
 function resetDb(done) {
   const defaults = {
@@ -17,7 +18,7 @@ function resetDb(done) {
     for (const [k, v] of Object.entries(defaults)) {
       stmt.run(k, v);
     }
-    stmt.run('adminPassword', require('bcryptjs').hashSync('admin', 10));
+    stmt.run('adminPassword', bcrypt.hashSync('admin', 10));
     stmt.finalize(done);
   });
 }


### PR DESCRIPTION
## Summary
- switch cueit-api package to native ES modules
- add `type: module` flag
- update test files to use `import` syntax

## Testing
- `npm test --silent` in `cueit-api`
- `npm run lint --silent` in `cueit-admin` *(fails: no-unused-vars, react-refresh/only-export-components, no-undef)*
- `npm test --silent` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_68662d0fe6e483338f2fc5871a244acf