### PR TITLE
Add SCIM user provisioning routes

### DIFF
--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -71,3 +71,19 @@ To enable SAML configure these variables in `.env`:
 - `SAML_CALLBACK_URL` – URL on this service that the IdP
   redirects to after authentication (e.g. `http://localhost:3000/login/callback`).
 - `ADMIN_URL` – URL of the admin frontend to redirect to after login.
+
+## SCIM Provisioning
+
+Set `SCIM_TOKEN` in your `.env` file to enable the SCIM 2.0 endpoints under
+`/scim/v2`. Identity providers must supply this token as a bearer token in the
+`Authorization` header when creating, updating or deleting users.
+
+Example user creation request:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $SCIM_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"userName":"john@example.com","displayName":"John"}' \
+  http://localhost:3000/scim/v2/Users
+```

--- a/cueit-api/test/00_setup.js
+++ b/cueit-api/test/00_setup.js
@@ -1,6 +1,7 @@
 import nodemailer from 'nodemailer';
 
 process.env.DISABLE_AUTH = 'true';
+process.env.SCIM_TOKEN = 'testtoken';
 let app;
 let sendBehavior = async () => {};
 const originalCreate = nodemailer.createTransport;

--- a/cueit-api/test/scim.test.js
+++ b/cueit-api/test/scim.test.js
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+const app = globalThis.app;
+
+const auth = (req) => req.set('Authorization', 'Bearer testtoken');
+
+beforeEach((done) => {
+  db.run('DELETE FROM users', done);
+});
+
+describe('SCIM user management', function() {
+  it('creates a user', async function() {
+    const payload = { userName: 'scim@example.com', displayName: 'Scim User' };
+    const res = await auth(request(app).post('/scim/v2/Users'))
+      .send(payload)
+      .expect(201);
+    assert(res.body.id, 'id missing');
+    const row = await new Promise((resolve) => {
+      db.get('SELECT * FROM users WHERE id=?', [res.body.id], (err, r) => resolve(r));
+    });
+    assert(row, 'db row missing');
+    assert.strictEqual(row.email, 'scim@example.com');
+  });
+
+  it('updates a user', async function() {
+    const id = await new Promise((resolve) => {
+      db.run('INSERT INTO users (name, email) VALUES (?, ?)', ['Old', 'old@e.com'], function(err) {
+        resolve(this.lastID);
+      });
+    });
+    const payload = { userName: 'new@example.com', displayName: 'New Name' };
+    const res = await auth(request(app).put(`/scim/v2/Users/${id}`))
+      .send(payload)
+      .expect(200);
+    assert.strictEqual(res.body.displayName, 'New Name');
+    const row = await new Promise((resolve) => {
+      db.get('SELECT * FROM users WHERE id=?', [id], (err, r) => resolve(r));
+    });
+    assert.strictEqual(row.name, 'New Name');
+    assert.strictEqual(row.email, 'new@example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add bearer protected SCIM routes under `/scim/v2`
- document SCIM configuration in backend README
- enable SCIM token in tests
- test SCIM user creation and update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866312eed5c8333a1922675c6161bfa