### PR TITLE
Add HelpScout integration

### DIFF
--- a/cueit-api/.env.example
+++ b/cueit-api/.env.example
@@ -11,3 +11,6 @@ SAML_ISSUER=https://cueit.example.com
 SAML_CERT=-----BEGIN CERTIFICATE-----\n...
 SAML_CALLBACK_URL=http://localhost:3000/login/callback
 ADMIN_URL=http://localhost:5173
+HELPSCOUT_API_KEY=
+HELPSCOUT_MAILBOX_ID=
+HELPSCOUT_SMTP_FALLBACK=false

--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -5,7 +5,9 @@ An Express and SQLite API that receives help desk tickets and stores configurati
 ## Setup
 1. Run `npm install` in this folder.
 2. Create a `.env` file with your SMTP details and set `HELPDESK_EMAIL`.
-   Optional variables are `API_PORT` and `LOGO_URL`.
+   To use HelpScout instead, provide `HELPSCOUT_API_KEY` and
+   `HELPSCOUT_MAILBOX_ID` (optionally `HELPSCOUT_SMTP_FALLBACK=true` to also
+   send email). Optional variables are `API_PORT` and `LOGO_URL`.
    For SAML login also provide `SESSION_SECRET`, `SAML_ENTRY_POINT`,
    `SAML_ISSUER`, `SAML_CERT`, `SAML_CALLBACK_URL` and optional
    `ADMIN_URL` used for the post-login redirect.
@@ -71,6 +73,9 @@ To enable SAML configure these variables in `.env`:
 - `SAML_CALLBACK_URL` – URL on this service that the IdP
   redirects to after authentication (e.g. `http://localhost:3000/login/callback`).
 - `ADMIN_URL` – URL of the admin frontend to redirect to after login.
+- `HELPSCOUT_API_KEY` – API key used to create HelpScout conversations.
+- `HELPSCOUT_MAILBOX_ID` – ID of the HelpScout mailbox.
+- `HELPSCOUT_SMTP_FALLBACK` – set to `true` to also send email via SMTP.
 
 ## SCIM Provisioning
 

--- a/cueit-api/test/00_setup.js
+++ b/cueit-api/test/00_setup.js
@@ -1,14 +1,19 @@
 import nodemailer from 'nodemailer';
+import axios from 'axios';
 
 process.env.DISABLE_AUTH = 'true';
 process.env.SCIM_TOKEN = 'testtoken';
 let app;
 let sendBehavior = async () => {};
+let axiosBehavior = async () => ({});
 const originalCreate = nodemailer.createTransport;
 
 nodemailer.createTransport = () => ({
   sendMail: (opts) => sendBehavior(opts),
 });
+
+const originalPost = axios.post;
+axios.post = (...args) => axiosBehavior(...args);
 
 const mod = await import('../index.js');
 app = mod.default;
@@ -18,6 +23,11 @@ globalThis.setSendBehavior = (fn) => {
   sendBehavior = fn;
 };
 
+globalThis.setAxiosBehavior = (fn) => {
+  axiosBehavior = fn;
+};
+
 after(() => {
   nodemailer.createTransport = originalCreate;
+  axios.post = originalPost;
 });


### PR DESCRIPTION
## Summary
- add HelpScout configuration variables
- send help desk tickets via HelpScout when API key is set
- document new configuration options
- extend tests to cover HelpScout behavior

## Testing
- `npm test` in `cueit-api`

------
https://chatgpt.com/codex/tasks/task_e_686638afb9c48333bf521a9982742931