### PR TITLE
Add interactive start scripts with env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ npx ngrok http $SLACK_PORT
 ### Running All Services
 
 Scripts are provided to launch the API, admin UI, activation page and Slack
-service together using `concurrently`.
+service together using `concurrently`. When running the script you will be
+prompted to choose which apps to start (press **Enter** for all). For each
+selected app the script verifies that a `.env` file exists and installs
+dependencies if the `node_modules` directory is missing.
 
 #### macOS / Linux
 

--- a/start-all.ps1
+++ b/start-all.ps1
@@ -1,6 +1,37 @@
-npx concurrently -k -n api,admin,activate,slack `
-  "node cueit-api/index.js" `
-  "npm --prefix cueit-admin run dev" `
-  "npm --prefix cueit-activate run dev" `
-  "node cueit-slack/index.js"
+$apps = @{
+  api      = @{ dir = 'cueit-api';      cmd = 'node cueit-api/index.js' }
+  admin    = @{ dir = 'cueit-admin';    cmd = 'npm --prefix cueit-admin run dev' }
+  activate = @{ dir = 'cueit-activate'; cmd = 'npm --prefix cueit-activate run dev' }
+  slack    = @{ dir = 'cueit-slack';    cmd = 'node cueit-slack/index.js' }
+}
+
+$input = Read-Host "Apps to start (api,admin,activate,slack or all) [all]"
+if ([string]::IsNullOrWhiteSpace($input) -or $input -eq 'all') {
+  $selected = $apps.Keys
+} else {
+  $selected = $input.Split(',') | ForEach-Object { $_.Trim() }
+}
+
+$names = @()
+$commands = @()
+foreach ($app in $selected) {
+  if (-not $apps.ContainsKey($app)) {
+    Write-Host "Unknown app: $app" -ForegroundColor Red
+    exit 1
+  }
+  $dir = $apps[$app].dir
+  if (-not (Test-Path "$dir/.env")) {
+    Write-Host "Error: $dir/.env not found. Copy $dir/.env.example first." -ForegroundColor Red
+    exit 1
+  }
+  if (-not (Test-Path "$dir/node_modules")) {
+    Write-Host "Installing dependencies for $dir..."
+    npm --prefix $dir install
+  }
+  $names += $app
+  $commands += $apps[$app].cmd
+}
+
+$nameStr = [string]::Join(',', $names)
+npx concurrently -k -n $nameStr $commands
 

--- a/start-all.sh
+++ b/start-all.sh
@@ -1,9 +1,47 @@
 #!/usr/bin/env bash
 set -e
 
-npx concurrently -k -n api,admin,activate,slack \
-  "node cueit-api/index.js" \
-  "npm --prefix cueit-admin run dev" \
-  "npm --prefix cueit-activate run dev" \
-  "node cueit-slack/index.js"
+declare -A DIRS=(
+  [api]="cueit-api"
+  [admin]="cueit-admin"
+  [activate]="cueit-activate"
+  [slack]="cueit-slack"
+)
+declare -A CMDS=(
+  [api]="node cueit-api/index.js"
+  [admin]="npm --prefix cueit-admin run dev"
+  [activate]="npm --prefix cueit-activate run dev"
+  [slack]="node cueit-slack/index.js"
+)
+
+read -rp "Apps to start (api,admin,activate,slack or all) [all]: " INPUT
+if [[ -z "$INPUT" || "$INPUT" == "all" ]]; then
+  SELECTED=(api admin activate slack)
+else
+  IFS=',' read -ra SELECTED <<< "$INPUT"
+fi
+
+NAMES=()
+COMMANDS=()
+for APP in "${SELECTED[@]}"; do
+  DIR=${DIRS[$APP]}
+  CMD=${CMDS[$APP]}
+  if [[ -z $DIR || -z $CMD ]]; then
+    echo "Unknown app: $APP" >&2
+    exit 1
+  fi
+  if [[ ! -f $DIR/.env ]]; then
+    echo "Error: $DIR/.env not found. Copy $DIR/.env.example first." >&2
+    exit 1
+  fi
+  if [[ ! -d $DIR/node_modules ]]; then
+    echo "Installing dependencies for $DIR..."
+    npm --prefix "$DIR" install
+  fi
+  NAMES+=("$APP")
+  COMMANDS+=("$CMD")
+done
+
+NAME_STR=$(IFS=','; echo "${NAMES[*]}")
+npx concurrently -k -n "$NAME_STR" "${COMMANDS[@]}"
 


### PR DESCRIPTION
## Summary
- allow users to choose which apps to start
- verify `.env` files and install missing dependencies
- dynamically construct `concurrently` command
- document the new behavior in `README`

## Testing
- `npm test` in `cueit-api`
- `npm install` & `npm run lint` in `cueit-admin`
- `npm test` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_68663cbd304c8333821224f64edc6ccd