### PR TITLE
Fix start-all.sh for macOS bash

### DIFF
--- a/start-all.sh
+++ b/start-all.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
-declare -A DIRS=(
-  [api]="cueit-api"
-  [admin]="cueit-admin"
-  [activate]="cueit-activate"
-  [slack]="cueit-slack"
-)
-declare -A CMDS=(
-  [api]="node cueit-api/index.js"
-  [admin]="npm --prefix cueit-admin run dev"
-  [activate]="npm --prefix cueit-activate run dev"
-  [slack]="node cueit-slack/index.js"
-)
+get_dir() {
+  case "$1" in
+    api) echo "cueit-api" ;;
+    admin) echo "cueit-admin" ;;
+    activate) echo "cueit-activate" ;;
+    slack) echo "cueit-slack" ;;
+    *) return 1 ;;
+  esac
+}
+
+get_cmd() {
+  case "$1" in
+    api) echo "node cueit-api/index.js" ;;
+    admin) echo "npm --prefix cueit-admin run dev" ;;
+    activate) echo "npm --prefix cueit-activate run dev" ;;
+    slack) echo "node cueit-slack/index.js" ;;
+    *) return 1 ;;
+  esac
+}
 
 read -rp "Apps to start (api,admin,activate,slack or all) [all]: " INPUT
 if [[ -z "$INPUT" || "$INPUT" == "all" ]]; then
@@ -24,12 +31,8 @@ fi
 NAMES=()
 COMMANDS=()
 for APP in "${SELECTED[@]}"; do
-  DIR=${DIRS[$APP]}
-  CMD=${CMDS[$APP]}
-  if [[ -z $DIR || -z $CMD ]]; then
-    echo "Unknown app: $APP" >&2
-    exit 1
-  fi
+  DIR=$(get_dir "$APP") || { echo "Unknown app: $APP" >&2; exit 1; }
+  CMD=$(get_cmd "$APP") || { echo "Unknown app: $APP" >&2; exit 1; }
   if [[ ! -f $DIR/.env ]]; then
     echo "Error: $DIR/.env not found. Copy $DIR/.env.example first." >&2
     exit 1


### PR DESCRIPTION
## Summary
- rewrite `start-all.sh` without associative arrays
- keep script compatible with older bash shells

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin` *(fails: Unable to find element)*
- `npm run lint` in `cueit-admin` *(fails: React lint errors)*
- `npm test` in `cueit-activate` *(fails: Missing script)*
- `npm test` in `cueit-slack` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68663eb0e4308333ae017ce88c5e276c