### PR TITLE
Add env examples and update start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ You can also follow the manual instructions below.
 ### Admin Frontend
 1. Navigate to `cueit-admin`.
 2. Run `npm install` to install dependencies.
-3. Create a `.env` file and set `VITE_API_URL` and `VITE_LOGO_URL`.
+3. Copy `.env.example` to `.env` and set `VITE_API_URL`. You can also set `VITE_LOGO_URL` and `VITE_ACTIVATE_URL`.
 4. Start the development server with `npm run dev` and open `http://localhost:5173`.
 
 ### Activation Page
 1. Navigate to `cueit-activate`.
 2. Run `npm install` to install dependencies.
-3. Create a `.env` file with `VITE_API_URL`.
+3. Copy `.env.example` to `.env` and set `VITE_API_URL`. Optionally set `VITE_ADMIN_URL`.
 4. Start the dev server with `npm run dev` and open the page to activate kiosks.
 
 The backend stores ticket logs in a local SQLite database (`cueit-api/log.sqlite`).
@@ -49,7 +49,7 @@ Configuration values are stored in the same database and can be edited from the 
 ### Slack Service
 1. Create a Slack app following [Slack's app setup guide](https://api.slack.com/apps) and add a `/new-ticket` slash command (see [Slash commands documentation](https://api.slack.com/interactivity/slash-commands)). Set its request URL to this service.
 2. Navigate to `cueit-slack` and run `npm install`.
-3. Create a `.env` file with:
+3. Copy `.env.example` to `.env` and set:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
    - `API_URL`

--- a/cueit-activate/README.md
+++ b/cueit-activate/README.md
@@ -4,8 +4,7 @@ A minimal React page for activating kiosks.
 
 ## Setup
 1. Run `npm install` in this folder.
-2. Create a `.env` with `VITE_API_URL` pointing to the backend. Optionally set
-   `VITE_ADMIN_URL` to the admin interface so a link appears on the page.
+2. Copy `.env.example` to `.env` and set `VITE_API_URL`. Optionally set `VITE_ADMIN_URL` to the admin interface so a link appears on the page.
 3. Start the dev server with `npm run dev`.
 
 ### Theme

--- a/cueit-admin/.env.example
+++ b/cueit-admin/.env.example
@@ -1,4 +1,3 @@
-VITE_LOGO_URL=/logo.png
 VITE_API_URL=http://localhost:3000
-VITE_FAVICON_URL=/vite.svg
+VITE_LOGO_URL=/logo.png
 VITE_ACTIVATE_URL=http://localhost:5174

--- a/cueit-admin/README.md
+++ b/cueit-admin/README.md
@@ -4,9 +4,7 @@ React based interface for viewing help desk tickets and managing system settings
 
 ## Setup
 1. Run `npm install` in this directory.
-2. Create a `.env` file with `VITE_API_URL` and optional `VITE_LOGO_URL`.
-   You can also set `VITE_ACTIVATE_URL` to display a link to the kiosk
-   activation page.
+2. Copy `.env.example` to `.env` and set `VITE_API_URL`. You can also set `VITE_LOGO_URL` and `VITE_ACTIVATE_URL`.
 3. Start the dev server with `npm run dev`.
 
 The admin UI lets you search tickets, edit configuration values, activate kiosk devices and manage users from the new **Users** tab in Settings.

--- a/cueit-slack/README.md
+++ b/cueit-slack/README.md
@@ -5,7 +5,7 @@ Slack slash command integration that lets users submit tickets directly from Sla
 ## Setup
 1. Create a Slack app (see [Slack's app setup docs](https://api.slack.com/apps)) and add a `/new-ticket` slash command. The [slash command guide](https://api.slack.com/interactivity/slash-commands) explains how to configure the command and obtain your tokens.
 2. Run `npm install` in this directory.
-3. Create a `.env` file with the following variables:
+3. Copy `.env.example` to `.env` and set:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
    - `API_URL`

--- a/start-all.ps1
+++ b/start-all.ps1
@@ -21,7 +21,7 @@ foreach ($app in $selected) {
   }
   $dir = $apps[$app].dir
   if (-not (Test-Path "$dir/.env")) {
-    Write-Host "Error: $dir/.env not found. Copy $dir/.env.example first." -ForegroundColor Red
+    Write-Host "Error: $dir/.env not found. Copy $dir/.env.example to $dir/.env." -ForegroundColor Red
     exit 1
   }
   if (-not (Test-Path "$dir/node_modules")) {

--- a/start-all.sh
+++ b/start-all.sh
@@ -34,7 +34,7 @@ for APP in "${SELECTED[@]}"; do
   DIR=$(get_dir "$APP") || { echo "Unknown app: $APP" >&2; exit 1; }
   CMD=$(get_cmd "$APP") || { echo "Unknown app: $APP" >&2; exit 1; }
   if [[ ! -f $DIR/.env ]]; then
-    echo "Error: $DIR/.env not found. Copy $DIR/.env.example first." >&2
+    echo "Error: $DIR/.env not found. Copy $DIR/.env.example to $DIR/.env." >&2
     exit 1
   fi
   if [[ ! -d $DIR/node_modules ]]; then


### PR DESCRIPTION
## Summary
- provide .env.example for `cueit-admin` with variables from docs
- document copying these examples when setting up each app
- show same instructions in `start-all` scripts

## Testing
- `npm --prefix cueit-admin run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix cueit-admin test` *(fails: jest not found)*
- `npm --prefix cueit-api test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686644f2cfc48333a3e9886bfe41369c