### PR TITLE
Check SESSION_SECRET before auth

### DIFF
--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -8,9 +8,11 @@ An Express and SQLite API that receives help desk tickets and stores configurati
    To use HelpScout instead, provide `HELPSCOUT_API_KEY` and
    `HELPSCOUT_MAILBOX_ID` (optionally `HELPSCOUT_SMTP_FALLBACK=true` to also
    send email). Optional variables are `API_PORT` and `LOGO_URL`.
-   For SAML login also provide `SESSION_SECRET`, `SAML_ENTRY_POINT`,
-   `SAML_ISSUER`, `SAML_CERT`, `SAML_CALLBACK_URL` and optional
-   `ADMIN_URL` used for the post-login redirect.
+  For SAML login also provide `SESSION_SECRET`, `SAML_ENTRY_POINT`,
+  `SAML_ISSUER`, `SAML_CERT`, `SAML_CALLBACK_URL` and optional
+  `ADMIN_URL` used for the post-login redirect. The server will
+  refuse to start if `SESSION_SECRET` is not set when authentication
+  is enabled.
 3. Start the server with `node index.js`.
 
 Kiosk devices register with `/api/register-kiosk` and can be activated through the admin UI.
@@ -66,7 +68,9 @@ retrieved from `/api/me`.
 
 To enable SAML configure these variables in `.env`:
 
-- `SESSION_SECRET` – secret used to sign the Express session cookie.
+- `SESSION_SECRET` – secret used to sign the Express session cookie. The API
+  exits during startup if this variable is missing and authentication is
+  enabled.
 - `SAML_ENTRY_POINT` – Identity Provider login URL.
 - `SAML_ISSUER` – the SP entity ID/issuer string.
 - `SAML_CERT` – IdP certificate used to validate responses.

--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -21,10 +21,15 @@ app.use(express.json());
 const DISABLE_AUTH = process.env.DISABLE_AUTH === 'true' || process.env.NODE_ENV === 'test';
 const SCIM_TOKEN = process.env.SCIM_TOKEN || '';
 
+if (!DISABLE_AUTH && !process.env.SESSION_SECRET) {
+  console.error('SESSION_SECRET environment variable is required');
+  process.exit(1);
+}
+
 if (!DISABLE_AUTH) {
   app.use(
     session({
-      secret: process.env.SESSION_SECRET || 'secret',
+      secret: process.env.SESSION_SECRET,
       resave: false,
       saveUninitialized: false,
     })


### PR DESCRIPTION
## Summary
- exit if SESSION_SECRET is missing when starting the API with auth enabled
- document the SESSION_SECRET requirement in the API README

## Testing
- `npm test` in `cueit-api`

------
https://chatgpt.com/codex/tasks/task_e_686644ec64ec8333a60feb9e6f84abd6