### PR TITLE
Fix axios mock for /api/me tests

### DIFF
--- a/cueit-admin/src/__tests__/App.test.jsx
+++ b/cueit-admin/src/__tests__/App.test.jsx
@@ -15,6 +15,7 @@ beforeEach(() => {
   axios.get.mockImplementation((url) => {
     if (url.endsWith('/api/logs')) return Promise.resolve({ data: logs });
     if (url.endsWith('/api/config')) return Promise.resolve({ data: {} });
+    if (url.endsWith('/api/me')) return Promise.resolve({ data: { name: 'Admin' } });
   });
   axios.put.mockResolvedValue({});
 });


### PR DESCRIPTION
## Summary
- handle `/api/me` requests in admin test mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686644e46100833390c9913ad8344328