### PR TITLE
Verify admin login via API

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
@@ -30,10 +30,12 @@ struct AdminLoginView: View {
                 }
 
                 Button("Login") {
-                    if password == configService.config.adminPassword {
-                        dismiss()
-                    } else {
-                        showError = true
+                    configService.verifyPassword(password) { ok in
+                        if ok {
+                            dismiss()
+                        } else {
+                            showError = true
+                        }
                     }
                 }
                 .padding(Theme.Spacing.sm)

--- a/cueit-kiosk/README.md
+++ b/cueit-kiosk/README.md
@@ -24,3 +24,10 @@ the app queries your identity provider's SCIM API. Add `SCIM_TOKEN` and
 `SCIM_URL` entries to `CueIT Kiosk/CueIT Kiosk/Info.plist`. `SCIM_TOKEN` should
 be a bearer token authorized for the directory service. `SCIM_URL` defaults to
 `\(API_BASE_URL)/scim/v2` when left blank.
+
+### Admin Login
+
+Tapping the gear icon on the welcome screen opens the admin login sheet. The
+entered password is sent to the backend via the `/api/verify-password` endpoint
+and never stored on the device. If the server verifies the password the sheet
+is dismissed, otherwise an error message is shown.


### PR DESCRIPTION
## Summary
- remove adminPassword from kiosk config and add API-based verification
- call `ConfigService.verifyPassword()` in `AdminLoginView`
- document admin login flow for kiosk

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin` *(fails: Unable to find element with the text: Alice)*
- `npm run lint` in `cueit-admin` *(fails: 28 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686644e8d098833394cfd1008db304c2