### PR TITLE
Add Jest env to admin ESLint config

### DIFF
--- a/cueit-admin/eslint.config.js
+++ b/cueit-admin/eslint.config.js
@@ -26,4 +26,14 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    files: ['src/__tests__/**'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+  },
 ])


### PR DESCRIPTION
## Summary
- enable Jest globals for admin tests

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686644e7aa9c833384e5a13a7c4d29da