### PR TITLE
Document DISABLE_AUTH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Each app relies on a few environment variables:
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – SMTP credentials used by
   Nodemailer.
 - Optional: `API_PORT` (default `3000`), `LOGO_URL`, `FAVICON_URL`.
+- `DISABLE_AUTH` – set to `true` to bypass SAML authentication and
+  access the admin UI before SSO is configured.
 
 ### Admin UI
 


### PR DESCRIPTION
## Summary
- explain DISABLE_AUTH in environment variables section

## Testing
- `npm run lint` in `cueit-admin` *(fails: cannot find module)*
- `npm test` in `cueit-admin` *(fails: jest not found)*
- `npm test` in `cueit-api` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba992da08333a5bb948671c8d7d7