### PR TITLE
Add macOS Electron launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ CueIT is an internal help desk application used to submit and track IT tickets. 
 - **cueit-kiosk** – iPad kiosk for ticket submission
 - **cueit-activate** – small React app for activating kiosks
 - **cueit-slack** – Slack slash command integration
+- **cueit-macos** – Electron launcher for macOS
 
 The `design/theme.js` file defines shared colors, fonts and spacing. Frontends
 import these tokens so styles remain consistent across the admin UI, activation
@@ -84,6 +85,11 @@ dependencies if the `node_modules` directory is missing.
 ./start-all.ps1
 ```
 
+### macOS Launcher
+
+Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./make-installer.sh` to build a `.pkg` installer, install it and launch **CueIT** from Applications.
+During development you can run `npm start` inside the folder to launch Electron without packaging.
+
 The SwiftUI kiosk can only be built and run on macOS with Xcode installed.
 
 ## Testing the API
@@ -147,6 +153,7 @@ check detects the change.
   `active` flag is enabled.
 - **cueit-activate** – Tiny React app that lets you quickly activate a kiosk by
   ID without using the full admin interface.
+- **cueit-macos** – Electron launcher for macOS
 - **cueit-slack** – Service handling the `/new-ticket` Slack slash command. It
   opens a modal and forwards submissions to the backend.
 

--- a/cueit-macos/index.html
+++ b/cueit-macos/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>CueIT Launcher</title>
+  <style>
+    body {
+      font-family: var(--font-sans);
+      padding: var(--spacing-md);
+    }
+    label {
+      margin-right: var(--spacing-md);
+    }
+    textarea {
+      width: 100%;
+      height: 300px;
+    }
+  </style>
+</head>
+<body>
+  <div>
+    <label><input type="checkbox" id="api" checked /> api</label>
+    <label><input type="checkbox" id="admin" /> admin</label>
+    <label><input type="checkbox" id="activate" /> activate</label>
+    <label><input type="checkbox" id="slack" /> slack</label>
+    <button id="start">Start</button>
+  </div>
+  <textarea id="log" readonly></textarea>
+  <script type="module" src="renderer.js"></script>
+</body>
+</html>

--- a/cueit-macos/main.js
+++ b/cueit-macos/main.js
@@ -1,0 +1,30 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let win;
+
+function createWindow() {
+  win = new BrowserWindow({
+    width: 600,
+    height: 500,
+    webPreferences: { preload: path.join(__dirname, 'preload.js') }
+  });
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.handle('start', (_e, apps) => {
+  const child = spawn(path.join(__dirname, '..', 'start-all.sh'), [], { shell: true });
+  child.stdin.write(`${apps}\n`);
+  child.stdin.end();
+  child.stdout.on('data', d => win.webContents.send('log', d.toString()));
+  child.stderr.on('data', d => win.webContents.send('log', d.toString()));
+});

--- a/cueit-macos/package.json
+++ b/cueit-macos/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cueit-macos",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^30.0.0"
+  }
+}

--- a/cueit-macos/preload.js
+++ b/cueit-macos/preload.js
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  start: apps => ipcRenderer.invoke('start', apps),
+  onLog: handler => ipcRenderer.on('log', (_e, data) => handler(data))
+});

--- a/cueit-macos/renderer.js
+++ b/cueit-macos/renderer.js
@@ -1,0 +1,17 @@
+import theme from './theme.js';
+
+document.documentElement.style.setProperty('--spacing-md', theme.spacing.md);
+document.documentElement.style.setProperty('--font-sans', theme.fonts.sans.join(','));
+
+document.getElementById('start').addEventListener('click', () => {
+  const apps = ['api', 'admin', 'activate', 'slack']
+    .filter(id => document.getElementById(id).checked)
+    .join(',');
+  window.electronAPI.start(apps);
+});
+
+const log = document.getElementById('log');
+window.electronAPI.onLog(line => {
+  log.value += line;
+  log.scrollTop = log.scrollHeight;
+});

--- a/cueit-macos/theme.js
+++ b/cueit-macos/theme.js
@@ -1,0 +1,2 @@
+export { default } from '../design/theme.js';
+export * from '../design/theme.js';

--- a/make-installer.sh
+++ b/make-installer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="cueit-macos"
+VERSION="${1:-1.0.0}"
+
+npm --prefix "$APP_DIR" install
+npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
+  --platform=darwin --out "$APP_DIR/dist" --overwrite
+
+APP_PATH="$APP_DIR/dist/CueIT-darwin-x64/CueIT.app"
+
+mkdir -p "$APP_DIR/dist/CueIT-darwin-x64/resources"
+cp -R cueit-api cueit-admin cueit-activate cueit-slack start-all.sh "$APP_DIR/dist/CueIT-darwin-x64/resources/"
+
+pkgbuild --root "$APP_PATH" --identifier com.cueit.launcher \
+  --version "$VERSION" "$APP_DIR/CueIT.pkg"
+productbuild --package "$APP_DIR/CueIT.pkg" "$APP_DIR/CueIT-$VERSION.pkg"
+
+echo "Installer created at $APP_DIR/CueIT-$VERSION.pkg"


### PR DESCRIPTION
## Summary
- add simple Electron launcher under `cueit-macos`
- package `cueit-macos` with `make-installer.sh`
- document macOS launcher in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686826a954008333aaca548d9a5d48d9