### PR TITLE
Fix lint for Toast.jsx

### DIFF
--- a/cueit-admin/src/Toast.jsx
+++ b/cueit-admin/src/Toast.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import ToastContext from './ToastContext.js';
 
-export function ToastProvider({ children }) {
+function ToastProvider({ children }) {
   const [toasts, setToasts] = useState([]);
 
   const show = (message, type = 'info') => {
@@ -30,5 +30,7 @@ export function ToastProvider({ children }) {
     </ToastContext.Provider>
   );
 }
+
+export default ToastProvider;
 
 


### PR DESCRIPTION
## Summary
- export ToastProvider as default so the `react-refresh/only-export-components` rule passes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686829a578588333b686a1a25dd53f1d