### PR TITLE
Add setup dialog to cueit-macos installer

### DIFF
--- a/cueit-macos/README.md
+++ b/cueit-macos/README.md
@@ -1,0 +1,16 @@
+# CueIT macOS Installer
+
+Electron launcher packaged for macOS.
+
+## Building
+
+Run `../make-installer.sh` to create `CueIT-<version>.pkg`. Install the package to `/Applications`.
+
+## Setup
+
+1. Launch the app after installation.
+2. On first run `.env.example` files are copied to `.env` for each service.
+3. A configuration window opens so you can edit the values for local or production.
+4. After saving the files the regular launcher window appears.
+
+Use the checkboxes to choose which services to start and click **Start**.

--- a/cueit-macos/main.js
+++ b/cueit-macos/main.js
@@ -2,20 +2,45 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { spawn } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { promises as fs } from 'fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packages = {
+  api: 'cueit-api',
+  admin: 'cueit-admin',
+  activate: 'cueit-activate',
+  slack: 'cueit-slack'
+};
 let win;
 
-function createWindow() {
+async function ensureEnvFiles() {
+  let created = false;
+  for (const dir of Object.values(packages)) {
+    const envPath = path.join(__dirname, '..', dir, '.env');
+    const example = path.join(__dirname, '..', dir, '.env.example');
+    try {
+      await fs.access(envPath);
+    } catch {
+      await fs.copyFile(example, envPath);
+      created = true;
+    }
+  }
+  return created;
+}
+
+function createWindow(showSetup) {
   win = new BrowserWindow({
     width: 600,
     height: 500,
     webPreferences: { preload: path.join(__dirname, 'preload.js') }
   });
-  win.loadFile('index.html');
+  win.loadFile(showSetup ? 'setup.html' : 'index.html');
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(async () => {
+  const firstRun = await ensureEnvFiles();
+  createWindow(firstRun);
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
@@ -27,4 +52,22 @@ ipcMain.handle('start', (_e, apps) => {
   child.stdin.end();
   child.stdout.on('data', d => win.webContents.send('log', d.toString()));
   child.stderr.on('data', d => win.webContents.send('log', d.toString()));
+});
+
+ipcMain.handle('read-envs', async () => {
+  const result = {};
+  for (const [name, dir] of Object.entries(packages)) {
+    const envPath = path.join(__dirname, '..', dir, '.env');
+    result[name] = await fs.readFile(envPath, 'utf8');
+  }
+  return result;
+});
+
+ipcMain.handle('write-envs', async (_e, envs) => {
+  for (const [name, content] of Object.entries(envs)) {
+    const dir = packages[name];
+    if (!dir) continue;
+    const envPath = path.join(__dirname, '..', dir, '.env');
+    await fs.writeFile(envPath, content);
+  }
 });

--- a/cueit-macos/preload.js
+++ b/cueit-macos/preload.js
@@ -2,5 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   start: apps => ipcRenderer.invoke('start', apps),
-  onLog: handler => ipcRenderer.on('log', (_e, data) => handler(data))
+  onLog: handler => ipcRenderer.on('log', (_e, data) => handler(data)),
+  readEnvs: () => ipcRenderer.invoke('read-envs'),
+  writeEnvs: envs => ipcRenderer.invoke('write-envs', envs)
 });

--- a/cueit-macos/setup.html
+++ b/cueit-macos/setup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>CueIT Setup</title>
+  <style>
+    body {
+      font-family: var(--font-sans);
+      padding: var(--spacing-md);
+    }
+    textarea {
+      width: 100%;
+      height: 120px;
+    }
+    .env-block {
+      margin-bottom: var(--spacing-md);
+    }
+  </style>
+</head>
+<body>
+  <h1>Environment Setup</h1>
+  <p>Edit the settings for each service.</p>
+  <div id="envs"></div>
+  <button id="save">Save</button>
+  <script type="module" src="setup.js"></script>
+</body>
+</html>

--- a/cueit-macos/setup.js
+++ b/cueit-macos/setup.js
@@ -1,0 +1,24 @@
+import theme from './theme.js';
+
+document.documentElement.style.setProperty('--spacing-md', theme.spacing.md);
+document.documentElement.style.setProperty('--font-sans', theme.fonts.sans.join(','));
+
+const envsDiv = document.getElementById('envs');
+const saveButton = document.getElementById('save');
+
+(async () => {
+  const envs = await window.electronAPI.readEnvs();
+  Object.entries(envs).forEach(([name, content]) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'env-block';
+    wrap.innerHTML = `<h2>${name}</h2><textarea id="${name}">${content}</textarea>`;
+    envsDiv.appendChild(wrap);
+  });
+})();
+
+saveButton.addEventListener('click', async () => {
+  const data = {};
+  envsDiv.querySelectorAll('textarea').forEach(t => { data[t.id] = t.value; });
+  await window.electronAPI.writeEnvs(data);
+  window.location = 'index.html';
+});


### PR DESCRIPTION
## Summary
- set up `cueit-macos` to copy `.env.example` on first run
- display a configuration window where users can edit `.env` values
- expose IPC helpers to read and write env files
- document installer usage in a new README

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin`
- `npm run lint` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_68682b1f9e2c8333bccdddebe87fb9ee