### PR TITLE
Relocate scripts under installers folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ page and SwiftUI kiosk app.
 
 ## Setup
 
-Run `./setup.sh` to install Node.js, SQLite and all project dependencies in one step.
+Run `./installers/setup.sh` to install Node.js, SQLite and all project dependencies in one step.
 You can also follow the manual instructions below.
 See [Local vs Production Setup](docs/environments.md) for details on configuring the environment variables used by each service.
 
@@ -77,18 +77,18 @@ dependencies if the `node_modules` directory is missing.
 #### macOS / Linux
 
 ```bash
-./start-all.sh
+./installers/start-all.sh
 ```
 
 #### Windows
 
 ```powershell
-./start-all.ps1
+./installers/start-all.ps1
 ```
 
 ### macOS Launcher
 
-Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./make-installer.sh` to build a `.pkg` installer, install it and launch **CueIT** from Applications.
+Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./installers/make-installer.sh` to build a `.pkg` installer, install it and launch **CueIT** from Applications.
 During development you can run `npm start` inside the folder to launch Electron without packaging.
 
 The SwiftUI kiosk can only be built and run on macOS with Xcode installed.

--- a/cueit-macos/README.md
+++ b/cueit-macos/README.md
@@ -4,7 +4,7 @@ Electron launcher packaged for macOS.
 
 ## Building
 
-Run `../make-installer.sh` to create `CueIT-<version>.pkg`. Install the package to `/Applications`.
+Run `../installers/make-installer.sh` to create `CueIT-<version>.pkg`. Install the package to `/Applications`.
 
 ## Setup
 

--- a/cueit-macos/main.js
+++ b/cueit-macos/main.js
@@ -47,7 +47,7 @@ app.on('window-all-closed', () => {
 });
 
 ipcMain.handle('start', (_e, apps) => {
-  const child = spawn(path.join(__dirname, '..', 'start-all.sh'), [], { shell: true });
+  const child = spawn(path.join(__dirname, '..', 'installers', 'start-all.sh'), [], { shell: true });
   child.stdin.write(`${apps}\n`);
   child.stdin.end();
   child.stdout.on('data', d => win.webContents.send('log', d.toString()));

--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
 APP_DIR="cueit-macos"
 VERSION="${1:-1.0.0}"
@@ -11,7 +13,7 @@ npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
 APP_PATH="$APP_DIR/dist/CueIT-darwin-x64/CueIT.app"
 
 mkdir -p "$APP_DIR/dist/CueIT-darwin-x64/resources"
-cp -R cueit-api cueit-admin cueit-activate cueit-slack start-all.sh "$APP_DIR/dist/CueIT-darwin-x64/resources/"
+cp -R cueit-api cueit-admin cueit-activate cueit-slack installers/start-all.sh "$APP_DIR/dist/CueIT-darwin-x64/resources/"
 
 pkgbuild --root "$APP_PATH" --identifier com.cueit.launcher \
   --version "$VERSION" "$APP_DIR/CueIT.pkg"

--- a/installers/setup.sh
+++ b/installers/setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
 # Ensure Node.js 18+ is installed
 if ! command -v node >/dev/null 2>&1 || \

--- a/installers/start-all.ps1
+++ b/installers/start-all.ps1
@@ -1,3 +1,4 @@
+Set-Location (Join-Path $PSScriptRoot "..")
 $apps = @{
   api      = @{ dir = 'cueit-api';      cmd = 'node cueit-api/index.js' }
   admin    = @{ dir = 'cueit-admin';    cmd = 'npm --prefix cueit-admin run dev' }

--- a/installers/start-all.sh
+++ b/installers/start-all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
 get_dir() {
   case "$1" in


### PR DESCRIPTION
## Summary
- move installer and service scripts to `installers/`
- update README instructions for new paths
- point macOS launcher and docs to the relocated scripts
- make scripts location aware so they work from any directory

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin`
- `npm run lint` in `cueit-admin`
- `npm test` in `cueit-activate`
- `npm test` in `cueit-slack`
- `./installers/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68682cf202188333ba0f38cc6ad49395