### PR TITLE
Refactor cueit-slack to ES modules

### DIFF
--- a/cueit-slack/__mocks__/@slack/bolt.js
+++ b/cueit-slack/__mocks__/@slack/bolt.js
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 const commandRegistry = {};
 const startMock = jest.fn().mockResolvedValue();
 
@@ -12,4 +14,4 @@ class App {
   }
 }
 
-module.exports = { App, __commandRegistry: commandRegistry, __startMock: startMock };
+export { App, commandRegistry as __commandRegistry, startMock as __startMock };

--- a/cueit-slack/index.js
+++ b/cueit-slack/index.js
@@ -1,6 +1,8 @@
-require('dotenv').config();
-const { App } = require('@slack/bolt');
-const axios = require('axios');
+import dotenv from 'dotenv';
+import { App } from '@slack/bolt';
+import axios from 'axios';
+
+dotenv.config();
 
 const PORT = process.env.SLACK_PORT || 3001;
 

--- a/cueit-slack/package.json
+++ b/cueit-slack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cueit-slack",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
@@ -9,7 +10,7 @@
     "dotenv": "^17.0.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "jest": "^29.6.1"

--- a/cueit-slack/test/index.test.js
+++ b/cueit-slack/test/index.test.js
@@ -1,6 +1,25 @@
-jest.mock('@slack/bolt');
-const { __commandRegistry } = require('@slack/bolt');
-require('..');
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('@slack/bolt', () => {
+  const commandRegistry = {};
+  const startMock = jest.fn().mockResolvedValue();
+
+  class App {
+    constructor() {}
+    command(name, handler) {
+      commandRegistry[name] = handler;
+    }
+    view() {}
+    start() {
+      return startMock();
+    }
+  }
+
+  return { App, __commandRegistry: commandRegistry, __startMock: startMock };
+});
+
+const { __commandRegistry } = await import('@slack/bolt');
+await import('..');
 
 describe('Slack command handler', () => {
   it('opens modal when /new-ticket is invoked', async () => {


### PR DESCRIPTION
## Summary
- migrate cueit-slack service to ES module syntax
- update manual Slack mock for ES modules
- adjust test to work with ESM
- enable Node ESM execution in package.json

## Testing
- `npm test` in `cueit-slack`

------
https://chatgpt.com/codex/tasks/task_e_68682e758c9883338f48c9262cb15c32