### PR TITLE
Add Windows and Linux installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,33 @@ During development you can run `npm start` inside the folder to launch Electron 
 
 The SwiftUI kiosk can only be built and run on macOS with Xcode installed.
 
+### Windows Installer
+
+Install [Inno Setup](https://jrsoftware.org/isinfo.php) along with Node.js and npm.
+Run the following command to generate `CueIT-<version>.exe`:
+
+```powershell
+./installers/make-windows-installer.ps1 -Version 1.0.0
+```
+
+Run the generated `.exe` to install CueIT.
+
+### Linux Installer
+
+Install `electron-installer-appimage` globally with:
+
+```bash
+npm install -g electron-installer-appimage
+```
+
+Then build the AppImage:
+
+```bash
+./installers/make-linux-installer.sh 1.0.0
+```
+
+Mark the output file executable and run it to start the application.
+
 ## Running Tests
 
 CueIT includes automated test suites for the backend API and the admin UI.

--- a/installers/CueIT.iss
+++ b/installers/CueIT.iss
@@ -1,0 +1,18 @@
+#define AppVersion GetStringParam('AppVersion')
+#define SourceDir GetStringParam('SourceDir')
+#define OutputDir GetStringParam('OutputDir')
+
+[Setup]
+AppName=CueIT
+AppVersion={#AppVersion}
+DefaultDirName={pf}\CueIT
+DisableProgramGroupPage=yes
+OutputDir={#OutputDir}
+OutputBaseFilename=CueIT-{#AppVersion}
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\CueIT"; Filename: "{app}\CueIT.exe"
+Name: "{userdesktop}\CueIT"; Filename: "{app}\CueIT.exe"

--- a/installers/make-linux-installer.sh
+++ b/installers/make-linux-installer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+APP_DIR="cueit-macos"
+VERSION="${1:-1.0.0}"
+
+npm --prefix "$APP_DIR" install
+npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
+  --platform=linux --out "$APP_DIR/dist" --overwrite
+
+APP_PATH="$APP_DIR/dist/CueIT-linux-x64"
+
+if ! command -v electron-installer-appimage >/dev/null 2>&1; then
+  echo "Installing electron-installer-appimage..."
+  npm install -g electron-installer-appimage
+fi
+
+CONFIG=$(mktemp)
+cat <<JSON > "$CONFIG"
+{
+  "productName": "CueIT",
+  "genericName": "CueIT",
+  "productVersion": "$VERSION"
+}
+JSON
+
+electron-installer-appimage --src "$APP_PATH" --dest "$APP_DIR" --arch x64 --config "$CONFIG"
+rm "$CONFIG"
+
+mv "$APP_DIR/CueIT-x86_64.AppImage" "$APP_DIR/CueIT-$VERSION-x86_64.AppImage"
+
+echo "Installer created at $APP_DIR/CueIT-$VERSION-x86_64.AppImage"

--- a/installers/make-windows-installer.ps1
+++ b/installers/make-windows-installer.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+param(
+  [string]$Version = '1.0.0'
+)
+
+Set-Location (Join-Path $PSScriptRoot '..')
+
+$AppDir = 'cueit-macos'
+
+npm --prefix $AppDir install
+npx --prefix $AppDir electron-packager $AppDir CueIT `
+  --platform=win32 --arch=x64 --out "$AppDir/dist" --overwrite
+
+$Source = Join-Path $AppDir 'dist/CueIT-win32-x64'
+$Inno = "$env:ProgramFiles(x86)\Inno Setup 6\ISCC.exe"
+if (-not (Test-Path $Inno)) {
+  Write-Host "Inno Setup not found at $Inno. Install from https://jrsoftware.org/isinfo.php." -ForegroundColor Yellow
+  exit 1
+}
+
+& $Inno 'installers/CueIT.iss' \
+  /DAppVersion=$Version \
+  /DSourceDir=$Source \
+  /DOutputDir=$AppDir
+
+Write-Host "Installer created at $AppDir\CueIT-$Version.exe"


### PR DESCRIPTION
## Summary
- add PowerShell script to build Windows installer using Inno Setup
- add Linux build script that produces an AppImage
- include an example Inno Setup script
- document how to run the platform installers

## Testing
- `./setup.sh` *(fails: No such file or directory)*
- `./installers/setup.sh`
- `npm run lint` in `cueit-admin`
- `npm test` in `cueit-admin`
- `npm test` in `cueit-activate`
- `npm test` in `cueit-slack`
- `npm test` in `cueit-api`


------
https://chatgpt.com/codex/tasks/task_e_68682e73602c8333a10c1e5a2b82f7db