### PR TITLE
Add Quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # CueIT
 
-CueIT is an internal help desk application used to submit and track IT tickets. The repository contains several apps:
+CueIT is an internal help desk application used to submit and track IT tickets.
+
+[→ Quickstart Guide](docs/quickstart.md)
+
+The repository contains several apps:
 
 - **cueit-api** – Express/SQLite API
 - **cueit-admin** – React admin interface

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart
+
+Follow these steps to get CueIT running quickly.
+
+## 1. Install
+
+Use the installer script for your operating system:
+
+- **macOS** – run `./installers/make-installer.sh` to create `CueIT-<version>.pkg` and then open the package.
+- **Windows** – run `./installers/make-windows-installer.ps1 -Version <version>` to build `CueIT-<version>.exe` and execute it.
+- **Linux** – run `./installers/make-linux-installer.sh <version>` to build an AppImage and launch it.
+
+These scripts package the Electron launcher along with the API and web apps.
+
+## 2. Configure
+
+After installing or cloning the repository, copy each `.env.example` file to `.env` and edit the values for your environment. See [Local vs Production Setup](environments.md) for details on every variable.
+
+## 3. Launch Services
+
+You can start all services from the command line:
+
+```bash
+./installers/start-all.sh
+```
+
+On Windows use `start-all.ps1` instead. The packaged Electron app created above also runs the same script in the background so you can start everything with a single click.


### PR DESCRIPTION
## Summary
- add quickstart instructions covering installation, basic configuration and launching
- link to the new quickstart guide from the top of `README.md`

## Testing
- `npm test` in `cueit-api`


------
https://chatgpt.com/codex/tasks/task_e_686830633ae0833393f6b41b3bfa070b