### PR TITLE
Add useApiError hook and refactor admin panels

### DIFF
--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import axios from 'axios';
 import Navbar from './Navbar';
 import SettingsPanel from './SettingsPanel';
 import useToast from './useToast.js';
+import useApiError from './useApiError.js';
 import './App.css';
 
 const urgencyPriority = { Urgent: 3, High: 2, Medium: 1, Low: 0 };
@@ -58,16 +59,7 @@ function App() {
   });
   const api = import.meta.env.VITE_API_URL;
 
-  const handleApiError = useCallback(
-    (err, msg) => {
-      if (err.response && err.response.status === 401) {
-        window.location.href = `${api}/login`;
-      } else if (msg) {
-        toast(msg, 'error');
-      }
-    },
-    [api, toast]
-  );
+  const handleApiError = useApiError();
 
   const deleteLog = async (id) => {
     try {

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import UsersPanel from './UsersPanel.jsx';
 import useToast from './useToast.js';
+import useApiError from './useApiError.js';
 
 export default function SettingsPanel({ open, onClose, config, setConfig }) {
   const [tab, setTab] = useState('general');
@@ -10,16 +11,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
   const api = import.meta.env.VITE_API_URL;
   const activateUrl = import.meta.env.VITE_ACTIVATE_URL;
   const toast = useToast();
-  const handleApiError = useCallback(
-    (err, msg) => {
-      if (err.response && err.response.status === 401) {
-        window.location.href = `${api}/login`;
-      } else {
-        toast(msg, 'error');
-      }
-    },
-    [api, toast]
-  );
+  const handleApiError = useApiError();
 
   useEffect(() => {
     if (open && tab === 'kiosks') {

--- a/cueit-admin/src/UsersPanel.jsx
+++ b/cueit-admin/src/UsersPanel.jsx
@@ -1,21 +1,11 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import useToast from './useToast.js';
+import useApiError from './useApiError.js';
 
 export default function UsersPanel({ open }) {
   const [users, setUsers] = useState([]);
   const api = import.meta.env.VITE_API_URL;
-  const toast = useToast();
-  const handleApiError = useCallback(
-    (err, msg) => {
-      if (err.response && err.response.status === 401) {
-        window.location.href = `${api}/login`;
-      } else {
-        toast(msg, 'error');
-      }
-    },
-    [api, toast]
-  );
+  const handleApiError = useApiError();
 
   useEffect(() => {
     if (open) {

--- a/cueit-admin/src/useApiError.js
+++ b/cueit-admin/src/useApiError.js
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+import useToast from './useToast.js';
+
+export default function useApiError() {
+  const api = import.meta.env.VITE_API_URL;
+  const toast = useToast();
+  return useCallback(
+    (err, msg) => {
+      if (err.response && err.response.status === 401) {
+        window.location.href = `${api}/login`;
+      } else if (msg) {
+        toast(msg, 'error');
+      }
+    },
+    [api, toast]
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `useApiError` hook for admin UI
- use the hook in `App`, `SettingsPanel` and `UsersPanel`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686831ca3a8c8333b48fd2d63aca931b