### PR TITLE
Update README auth details

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Each app relies on a few environment variables:
 
 Several security and usability features are planned for a future version of the API and frontends:
 
-- **Authentication** – add JWT based auth to protect admin and Slack endpoints and store hashed admin passwords instead of plaintext.
+- **Authentication** – current admin login uses SAML. Add JWT based auth to protect API and Slack endpoints.
 - **Log filtering** – allow filtering ticket logs by date range or email status when querying the `/api/logs` endpoint.
 - **HTTPS** – enable TLS so the backend, admin UI and kiosk all communicate over HTTPS.
 - **Kiosk registration tokens** – require a token when calling `/api/register-kiosk` to prevent unauthorized devices from spoofing a kiosk ID.


### PR DESCRIPTION
## Summary
- clarify SAML login in README
- remove outdated plaintext password note

## Testing
- `./installers/setup.sh`
- `npm test --silent` in `cueit-api`
- `npm test --silent` in `cueit-admin`
- `npm test --silent` in `cueit-activate`
- `npm test --silent` in `cueit-slack`
- `npm run lint --silent` in `cueit-admin` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686838cbb7788333a9063834193abb3a