### PR TITLE
Handle kiosk config and activation errors

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
@@ -10,20 +10,38 @@ struct AppConfig: Codable {
 
 class ConfigService: ObservableObject {
     @Published var config: AppConfig = AppConfig(logoUrl: "/logo.png", backgroundUrl: nil, welcomeMessage: "Welcome", helpMessage: "Need help?")
+    @Published var errorMessage: String?
 
     func load() {
-        if let data = UserDefaults.standard.data(forKey: "config"),
-           let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) {
-            self.config = cfg
+        if let data = UserDefaults.standard.data(forKey: "config") {
+            do {
+                let cfg = try JSONDecoder().decode(AppConfig.self, from: data)
+                self.config = cfg
+            } catch {
+                self.errorMessage = "Unable to load configuration"
+            }
         }
-        guard let url = URL(string: "\(APIConfig.baseURL)/api/config") else { return }
+
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/config") else {
+            self.errorMessage = "Unable to load configuration"
+            return
+        }
+
         URLSession.shared.dataTask(with: url) { data, _, _ in
-            if let data = data, let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) {
-                DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                guard let data = data else {
+                    self.errorMessage = "Unable to load configuration"
+                    return
+                }
+                do {
+                    let cfg = try JSONDecoder().decode(AppConfig.self, from: data)
                     self.config = cfg
+                    self.errorMessage = nil
                     if let d = try? JSONEncoder().encode(cfg) {
                         UserDefaults.standard.set(d, forKey: "config")
                     }
+                } catch {
+                    self.errorMessage = "Unable to load configuration"
                 }
             }
         }.resume()
@@ -33,10 +51,13 @@ class ConfigService: ObservableObject {
            let kurl = URL(string: "\(APIConfig.baseURL)/api/kiosks/\(kioskId)") {
             struct KioskConfig: Codable { var logoUrl: String?; var bgUrl: String? }
             URLSession.shared.dataTask(with: kurl) { data, _, _ in
-                if let data = data, let row = try? JSONDecoder().decode(KioskConfig.self, from: data) {
-                    DispatchQueue.main.async {
+                DispatchQueue.main.async {
+                    if let data = data, let row = try? JSONDecoder().decode(KioskConfig.self, from: data) {
                         if let bg = row.bgUrl { self.config.backgroundUrl = bg }
                         if let l = row.logoUrl { self.config.logoUrl = l }
+                        self.errorMessage = nil
+                    } else {
+                        self.errorMessage = "Unable to load configuration"
                     }
                 }
             }.resume()

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
@@ -15,6 +15,7 @@ class KioskService: ObservableObject {
     }
 
     @Published var state: ActivationState = .checking
+    @Published var activationError: Bool = false
     private var timer: Timer?
 
     let id: String = {
@@ -44,8 +45,10 @@ class KioskService: ObservableObject {
                 if let data = data,
                    let row = try? JSONDecoder().decode(KioskRow.self, from: data) {
                     self.state = row.active == 1 ? .active : .inactive
+                    self.activationError = false
                 } else {
                     self.state = .error
+                    self.activationError = true
                 }
             }
         }.resume()

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -12,6 +12,8 @@ struct LaunchView: View {
     @State private var showAdmin = false
     @StateObject private var configService = ConfigService()
     @StateObject private var kioskService = KioskService.shared
+    @State private var showAlert = false
+    @State private var alertMessage = ""
 
     var body: some View {
         ZStack {
@@ -69,6 +71,22 @@ struct LaunchView: View {
         .onAppear {
             configService.load()
         }
+        .onReceive(configService.$errorMessage) { msg in
+            if let m = msg {
+                alertMessage = m
+                showAlert = true
+            } else if showAlert && alertMessage == "Unable to load configuration" {
+                showAlert = false
+            }
+        }
+        .onReceive(kioskService.$activationError) { failed in
+            if failed {
+                alertMessage = "Unable to verify kiosk status"
+                showAlert = true
+            } else if showAlert && alertMessage == "Unable to verify kiosk status" {
+                showAlert = false
+            }
+        }
         .overlay(
             HStack {
                 Spacer()
@@ -87,5 +105,8 @@ struct LaunchView: View {
             },
             alignment: .topTrailing
         )
+        .alert(alertMessage, isPresented: $showAlert) {
+            Button("OK", role: .cancel) {}
+        }
     }
 }


### PR DESCRIPTION
## Summary
- surface errors from `ConfigService` when the app configuration fails to load
- track kiosk activation failures via `KioskService`
- present alerts in `LaunchView` for configuration and activation errors

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68683cd18e7083339c7bb7b3eb63206d