### PR TITLE
Add accessibility label to settings button

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -101,6 +101,7 @@ struct LaunchView: View {
                             .padding(.top, Theme.Spacing.md)
                             .padding(.trailing, Theme.Spacing.md)
                     }
+                    .accessibilityLabel("Settings")
                     Spacer()
                 }
             },


### PR DESCRIPTION
## Summary
- add an accessibility label to the gear settings button

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686852fe8d3c83339c5957aeac3d820d