### PR TITLE
Add log filtering

### DIFF
--- a/cueit-admin/src/__tests__/App.test.jsx
+++ b/cueit-admin/src/__tests__/App.test.jsx
@@ -13,7 +13,7 @@ const logs = [
 beforeEach(() => {
   process.env.VITE_API_URL = 'http://localhost';
   axios.get.mockImplementation((url) => {
-    if (url.endsWith('/api/logs')) return Promise.resolve({ data: logs });
+    if (url.includes('/api/logs')) return Promise.resolve({ data: logs });
     if (url.endsWith('/api/config')) return Promise.resolve({ data: {} });
     if (url.endsWith('/api/me')) return Promise.resolve({ data: { name: 'Admin' } });
   });

--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -36,7 +36,11 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
 
 ### Logs and Configuration
 
-- `GET /api/logs` – return all ticket logs sorted by timestamp.
+- `GET /api/logs` – return ticket logs sorted by timestamp. Optional query
+  parameters:
+  - `start` – ISO timestamp to filter logs on or after this time.
+  - `end` – ISO timestamp to filter logs on or before this time.
+  - `status` – filter by `email_status` value (`success` or `fail`).
 - `DELETE /api/logs/:id` – delete a log entry by numeric id.
 - `DELETE /api/logs` – remove all log entries.
 - `GET /api/config` – return configuration key/value pairs.

--- a/cueit-api/test/logs.test.js
+++ b/cueit-api/test/logs.test.js
@@ -1,0 +1,54 @@
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+
+const app = globalThis.app;
+
+function resetDb(done) {
+  db.run('DELETE FROM logs', done);
+}
+
+describe('GET /api/logs filters', function() {
+  beforeEach((done) => {
+    resetDb(() => {
+      db.serialize(() => {
+        db.run(
+          `INSERT INTO logs (ticket_id, name, email, title, system, urgency, timestamp, email_status)
+           VALUES ('1', 'A', 'a@x.com', 'T1', 'Sys', 'High', '2024-06-01T10:00:00Z', 'success')`
+        );
+        db.run(
+          `INSERT INTO logs (ticket_id, name, email, title, system, urgency, timestamp, email_status)
+           VALUES ('2', 'B', 'b@x.com', 'T2', 'Sys', 'Low', '2024-06-05T10:00:00Z', 'fail')`
+        );
+        db.run(
+          `INSERT INTO logs (ticket_id, name, email, title, system, urgency, timestamp, email_status)
+           VALUES ('3', 'C', 'c@x.com', 'T3', 'Sys', 'Low', '2024-06-10T10:00:00Z', 'success')`,
+          done
+        );
+      });
+    });
+  });
+
+  it('returns all logs by default', async function() {
+    const res = await request(app).get('/api/logs').expect(200);
+    assert.strictEqual(res.body.length, 3);
+  });
+
+  it('filters by date range', async function() {
+    const res = await request(app)
+      .get('/api/logs')
+      .query({ start: '2024-06-02', end: '2024-06-09' })
+      .expect(200);
+    assert.strictEqual(res.body.length, 1);
+    assert.strictEqual(res.body[0].ticket_id, '2');
+  });
+
+  it('filters by status', async function() {
+    const res = await request(app)
+      .get('/api/logs')
+      .query({ status: 'fail' })
+      .expect(200);
+    assert.strictEqual(res.body.length, 1);
+    assert.strictEqual(res.body[0].email_status, 'fail');
+  });
+});


### PR DESCRIPTION
## Summary
- support filtering logs by date or status in the API
- expose filter controls in the admin UI
- document new query parameters
- test filtered log queries

## Testing
- `npm test --silent` in `cueit-api`
- `npx jest --runInBand` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_68685bb40d208333a149d59204a23d2e