### PR TITLE
Move SCIM token to runtime configuration

### DIFF
--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -74,7 +74,8 @@ db.serialize(() => {
     faviconUrl: process.env.FAVICON_URL || '/vite.svg',
     welcomeMessage: 'Welcome to the Help Desk',
     helpMessage: 'Need to report an issue?',
-    adminPassword: bcrypt.hashSync(process.env.ADMIN_PASSWORD || 'admin', 10)
+    adminPassword: bcrypt.hashSync(process.env.ADMIN_PASSWORD || 'admin', 10),
+    scimToken: process.env.SCIM_TOKEN || ''
   };
   const stmt = db.prepare(`INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)`);
   for (const [key, value] of Object.entries(defaults)) {

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
@@ -4,11 +4,9 @@
 <dict>
     <key>API_BASE_URL</key>
     <string>http://localhost:3000</string>
-    <key>SCIM_TOKEN</key>
+    <key>SCIM_URL</key>
     <string></string>
-<key>SCIM_URL</key>
-<string></string>
-<key>KIOSK_TOKEN</key>
-<string></string>
+    <key>KIOSK_TOKEN</key>
+    <string></string>
 </dict>
 </plist>

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/ConfigService.swift
@@ -6,6 +6,7 @@ struct AppConfig: Codable {
     var backgroundUrl: String?
     var welcomeMessage: String
     var helpMessage: String
+    var scimToken: String?
 }
 
 class ConfigService: ObservableObject {
@@ -16,7 +17,8 @@ class ConfigService: ObservableObject {
     func load() async {
         if let data = UserDefaults.standard.data(forKey: "config") {
             do {
-                let cfg = try JSONDecoder().decode(AppConfig.self, from: data)
+                var cfg = try JSONDecoder().decode(AppConfig.self, from: data)
+                cfg.scimToken = nil
                 self.config = cfg
             } catch {
                 self.errorMessage = "Unable to load configuration"
@@ -30,7 +32,9 @@ class ConfigService: ObservableObject {
 
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
-            let cfg = try JSONDecoder().decode(AppConfig.self, from: data)
+            var cfg = try JSONDecoder().decode(AppConfig.self, from: data)
+            if let token = cfg.scimToken { DirectoryService.shared.updateToken(token) }
+            cfg.scimToken = nil
             self.config = cfg
             self.errorMessage = nil
             if let d = try? JSONEncoder().encode(cfg) {

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/DirectoryService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/DirectoryService.swift
@@ -12,16 +12,22 @@ class DirectoryService: ObservableObject {
     static let shared = DirectoryService()
     @Published var suggestions: [DirectoryUser] = []
 
-    private let token: String
     private let baseURL: String
 
     private init() {
-        token = Bundle.main.object(forInfoDictionaryKey: "SCIM_TOKEN") as? String ?? ""
         if let url = Bundle.main.object(forInfoDictionaryKey: "SCIM_URL") as? String {
             baseURL = url
         } else {
             baseURL = "\(APIConfig.baseURL)/scim/v2"
         }
+    }
+
+    var token: String {
+        KeychainService.string(for: "scimToken") ?? ""
+    }
+
+    func updateToken(_ value: String) {
+        KeychainService.set(value, for: "scimToken")
     }
 
     func search(email: String) {

--- a/cueit-kiosk/CueIT KioskTests/DirectoryServiceTests.swift
+++ b/cueit-kiosk/CueIT KioskTests/DirectoryServiceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CueIT_Kiosk
+
+final class DirectoryServiceTests: XCTestCase {
+    func testTokenPersistsInKeychain() {
+        KeychainService.delete("scimToken")
+        DirectoryService.shared.updateToken("abc")
+        XCTAssertEqual(KeychainService.string(for: "scimToken"), "abc")
+        XCTAssertEqual(DirectoryService.shared.token, "abc")
+    }
+}

--- a/cueit-kiosk/README.md
+++ b/cueit-kiosk/README.md
@@ -21,11 +21,12 @@ matches the web interfaces.
 
 ### Directory Lookup
 
-To automatically populate the ticket form with a user's job title and manager
-the app queries your identity provider's SCIM API. Add `SCIM_TOKEN` and
-`SCIM_URL` entries to `CueIT Kiosk/CueIT Kiosk/Info.plist`. `SCIM_TOKEN` should
-be a bearer token authorized for the directory service. `SCIM_URL` defaults to
-`\(API_BASE_URL)/scim/v2` when left blank.
+To automatically populate the ticket form with a user's job title and manager,
+the app queries your identity provider's SCIM API. The token for this request is
+retrieved at runtime from the backend (or entered in settings) and stored
+securely in the keychain. Add a `SCIM_URL` entry to
+`CueIT Kiosk/CueIT Kiosk/Info.plist` if the directory endpoint differs from the
+default of `\(API_BASE_URL)/scim/v2`.
 
 ### Admin Login
 


### PR DESCRIPTION
## Summary
- load SCIM token from the keychain instead of Info.plist
- cache SCIM token when downloading configuration
- note new runtime storage in kiosk README
- include default `scimToken` value in API config
- add DirectoryService keychain test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68685f5bc3d48333afc2f16df32bb3d6