### PR TITLE
Add environment setup reminder

### DIFF
--- a/installers/setup.sh
+++ b/installers/setup.sh
@@ -43,4 +43,5 @@ if [ -d cueit-slack ]; then
   popd >/dev/null
 fi
 
+echo "Run ./scripts/init-env.sh to create .env files, then edit them before starting the services."
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- update `installers/setup.sh` to tell users to run `init-env.sh`

## Testing
- `npm test` in `cueit-api`
- `npm run lint` and `npm test` in `cueit-admin`
- `npm test` in `cueit-activate`
- `npm test` in `cueit-slack`

------
https://chatgpt.com/codex/tasks/task_e_6868617deaf483339e5ab9ee282bd788