### PR TITLE
Add privacy policy and kiosk link

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/AdminLoginView.swift
@@ -13,6 +13,7 @@ struct AdminLoginView: View {
     @State private var password = ""
     @State private var errorText: String?
     @State private var loading = false
+    @State private var showPolicy = false
 
     var body: some View {
         NavigationView {
@@ -55,6 +56,14 @@ struct AdminLoginView: View {
             }
             .padding(Theme.Spacing.md)
             .navigationTitle("Admin Login")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Privacy") { showPolicy = true }
+                }
+            }
+        }
+        .sheet(isPresented: $showPolicy) {
+            PrivacyPolicyView()
         }
     }
 }

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/PrivacyPolicyView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/PrivacyPolicyView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PrivacyPolicyView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("CueIT collects the following information when a ticket is submitted:")
+                    Text("\u2022 Name")
+                    Text("\u2022 Email address")
+                    Text("\u2022 Job title")
+                    Text("\u2022 Manager")
+                    Text("\u2022 System affected")
+                    Text("\u2022 Urgency level")
+                    Text("\nThis data is sent to the CueIT backend to create and track help desk requests. Nothing is stored on the kiosk. Ticket details are kept for 30 days then removed from the database.")
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.body)
+            }
+            .navigationTitle("Privacy Policy")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct PrivacyPolicyView_Previews: PreviewProvider {
+    static var previews: some View {
+        PrivacyPolicyView()
+    }
+}

--- a/cueit-kiosk/README.md
+++ b/cueit-kiosk/README.md
@@ -40,3 +40,7 @@ is dismissed, otherwise an error message is shown.
 Unit tests live in `CueIT KioskTests`. Open the project in Xcode and select
 **Product → Test** or press `⌘U` to run them. The suite verifies configuration
 loading and kiosk startup behavior.
+
+## Privacy
+
+See [docs/privacy-policy.md](../docs/privacy-policy.md) for details about the data collected by the kiosk and how it is retained.

--- a/cueit-kiosk/metadata/en-US/description.txt
+++ b/cueit-kiosk/metadata/en-US/description.txt
@@ -1,0 +1,1 @@
+CueIT Kiosk lets employees submit help desk tickets from a shared iPad. The app collects the user's name, email, title, manager, affected system and urgency level to create the request. See the in-app privacy policy or docs/privacy-policy.md for details.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,12 @@
+# Privacy Policy
+
+CueIT collects a minimal amount of information when a ticket is submitted through the kiosk or web interfaces. The following data is sent to the CueIT backend:
+
+- Name
+- Email address
+- Job title
+- Manager
+- System affected
+- Urgency level
+
+This information is used solely to create and track help desk tickets. No personal data is stored on the kiosk device. Ticket details are retained in the backend database for 30 days before being automatically deleted.


### PR DESCRIPTION
## Summary
- add privacy policy markdown
- reference policy from kiosk README
- show Privacy Policy screen from the admin login
- include App Store metadata mention

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68686202676883338f346862a7fdbb11