### PR TITLE
Switch kiosk base URL to HTTPS

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>API_BASE_URL</key>
-    <string>http://localhost:3000</string>
+    <string>https://localhost:3000</string>
     <key>SCIM_URL</key>
     <string></string>
     <key>KIOSK_TOKEN</key>

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/APIConfig.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/APIConfig.swift
@@ -5,6 +5,6 @@ enum APIConfig {
         if let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String {
             return url
         }
-        return "http://localhost:3000"
+        return "https://localhost:3000"
     }
 }

--- a/cueit-kiosk/CueIT KioskTests/APIConfigTests.swift
+++ b/cueit-kiosk/CueIT KioskTests/APIConfigTests.swift
@@ -3,6 +3,6 @@ import XCTest
 
 final class APIConfigTests: XCTestCase {
     func testDefaultBaseURL() {
-        XCTAssertEqual(APIConfig.baseURL, "http://localhost:3000")
+        XCTAssertEqual(APIConfig.baseURL, "https://localhost:3000")
     }
 }


### PR DESCRIPTION
## Summary
- update `API_BASE_URL` to use HTTPS
- update Swift config helper to default to HTTPS
- update tests to expect HTTPS

## Testing
- `xcodebuild -project "CueIT Kiosk.xcodeproj" -scheme "CueIT Kiosk" -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868632419b483339a9bd20cd1a0e3f4