### PR TITLE
Update macOS installer for universal builds

### DIFF
--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -6,16 +6,21 @@ cd "$SCRIPT_DIR/.."
 APP_DIR="cueit-macos"
 VERSION="${1:-1.0.0}"
 
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="x64"
+fi
+
 npm --prefix "$APP_DIR" install
 npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
-  --platform=darwin --out "$APP_DIR/dist" --overwrite
+  --platform=darwin --arch="$arch" --out "$APP_DIR/dist" --overwrite
 
-APP_PATH="$APP_DIR/dist/CueIT-darwin-x64/CueIT.app"
+APP_PATH="$APP_DIR/dist/CueIT-darwin-$arch/CueIT.app"
 
-mkdir -p "$APP_DIR/dist/CueIT-darwin-x64/resources"
-cp -R cueit-api cueit-admin cueit-activate cueit-slack installers/start-all.sh "$APP_DIR/dist/CueIT-darwin-x64/resources/"
+mkdir -p "$APP_DIR/dist/CueIT-darwin-$arch/resources"
+cp -R cueit-api cueit-admin cueit-activate cueit-slack installers/start-all.sh "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
 if [[ -f cert.pem && -f key.pem ]]; then
-  cp cert.pem key.pem "$APP_DIR/dist/CueIT-darwin-x64/resources/"
+  cp cert.pem key.pem "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
 fi
 
 pkgbuild --root "$APP_PATH" --identifier com.cueit.launcher \


### PR DESCRIPTION
## Summary
- handle host architecture when building CueIT installer

## Testing
- `npm --prefix cueit-api install`
- `npm --prefix cueit-api test`
- `npm --prefix cueit-admin install`
- `npm --prefix cueit-admin test`
- `npm --prefix cueit-admin run lint`
- `npm --prefix cueit-activate install`
- `npm --prefix cueit-activate test`
- `npm --prefix cueit-slack install`
- `npm --prefix cueit-slack test`
- `npm --prefix cueit-macos install`
- `npm --prefix cueit-macos test`


------
https://chatgpt.com/codex/tasks/task_e_6868679996fc8333a87737b0927b4ec4