### PR TITLE
Fix macOS installer location

### DIFF
--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -23,8 +23,8 @@ if [[ -f cert.pem && -f key.pem ]]; then
   cp cert.pem key.pem "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
 fi
 
-pkgbuild --root "$APP_PATH" --identifier com.cueit.launcher \
-  --version "$VERSION" "$APP_DIR/CueIT.pkg"
+pkgbuild --root "$APP_PATH" --install-location /Applications \
+  --identifier com.cueit.launcher --version "$VERSION" "$APP_DIR/CueIT.pkg"
 productbuild --package "$APP_DIR/CueIT.pkg" "$APP_DIR/CueIT-$VERSION.pkg"
 
 echo "Installer created at $APP_DIR/CueIT-$VERSION.pkg"


### PR DESCRIPTION
## Summary
- update `make-installer.sh` so pkg installs to `/Applications`

## Testing
- `./installers/setup.sh` *(fails: lock file mismatch)*
- `npm test` in packages *(fails: missing dependencies)*
- `npm run lint` in `cueit-admin` *(fails: missing ESLint deps)*
- `./installers/make-installer.sh` *(fails: interactive npx prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6868693cec58833397539e4a44896787