### PR TITLE
Fix mac installer env setup

### DIFF
--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -17,10 +17,17 @@ npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
 
 APP_PATH="$APP_DIR/dist/CueIT-darwin-$arch/CueIT.app"
 
-mkdir -p "$APP_DIR/dist/CueIT-darwin-$arch/resources"
-cp -R cueit-api cueit-admin cueit-activate cueit-slack installers/start-all.sh "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
+RES_DIR="$APP_DIR/dist/CueIT-darwin-$arch/resources"
+mkdir -p "$RES_DIR/installers"
+cp -R cueit-api cueit-admin cueit-activate cueit-slack design "$RES_DIR/"
+cp installers/start-all.sh "$RES_DIR/installers/"
+# copy .env.example to .env so the launcher does not need to write inside
+# the application bundle on first run
+for pkg in cueit-api cueit-admin cueit-activate cueit-slack; do
+  cp "$pkg/.env.example" "$RES_DIR/$pkg/.env"
+done
 if [[ -f cert.pem && -f key.pem ]]; then
-  cp cert.pem key.pem "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
+  cp cert.pem key.pem "$RES_DIR/"
 fi
 
 pkgbuild --root "$APP_PATH" --install-location /Applications \


### PR DESCRIPTION
## Summary
- copy design assets and sample configs when packaging macOS app
- include start-all.sh under an `installers` directory
- create `.env` files during packaging so first run works without write access

## Testing
- `npm install --no-progress` in `cueit-macos`
- `npm test` in `cueit-macos`


------
https://chatgpt.com/codex/tasks/task_e_68686c2a5b0c8333a59f73ae31c340a6