### PR TITLE
Improve macOS installer experience

### DIFF
--- a/cueit-macos/index.html
+++ b/cueit-macos/index.html
@@ -11,6 +11,9 @@
     label {
       margin-right: var(--spacing-md);
     }
+    pre {
+      margin-top: var(--spacing-md);
+    }
     textarea {
       width: 100%;
       height: 300px;
@@ -25,6 +28,7 @@
     <label><input type="checkbox" id="slack" /> slack</label>
     <button id="start">Start</button>
   </div>
+  <pre id="status"></pre>
   <textarea id="log" readonly></textarea>
   <script type="module" src="renderer.js"></script>
 </body>

--- a/cueit-macos/main.js
+++ b/cueit-macos/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import { spawn } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -74,6 +74,10 @@ ipcMain.handle('write-envs', async (_e, envs) => {
     const envPath = path.join(__dirname, '..', dir, '.env');
     await fs.writeFile(envPath, content);
   }
+});
+
+ipcMain.handle('open-external', (_e, url) => {
+  shell.openExternal(url);
 });
 
 export { ensureEnvFiles, createWindow, start };

--- a/cueit-macos/preload.js
+++ b/cueit-macos/preload.js
@@ -4,5 +4,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   start: apps => ipcRenderer.invoke('start', apps),
   onLog: handler => ipcRenderer.on('log', (_e, data) => handler(data)),
   readEnvs: () => ipcRenderer.invoke('read-envs'),
-  writeEnvs: envs => ipcRenderer.invoke('write-envs', envs)
+  writeEnvs: envs => ipcRenderer.invoke('write-envs', envs),
+  openExternal: url => ipcRenderer.invoke('open-external', url)
 });

--- a/cueit-macos/renderer.js
+++ b/cueit-macos/renderer.js
@@ -3,11 +3,24 @@ import theme from './theme.js';
 document.documentElement.style.setProperty('--spacing-md', theme.spacing.md);
 document.documentElement.style.setProperty('--font-sans', theme.fonts.sans.join(','));
 
+const urls = {
+  api: 'http://localhost:3000',
+  admin: 'http://localhost:5173',
+  activate: 'http://localhost:5174'
+};
+
+const status = document.getElementById('status');
 document.getElementById('start').addEventListener('click', () => {
-  const apps = ['api', 'admin', 'activate', 'slack']
-    .filter(id => document.getElementById(id).checked)
-    .join(',');
-  window.electronAPI.start(apps);
+  const selected = ['api', 'admin', 'activate', 'slack']
+    .filter(id => document.getElementById(id).checked);
+  window.electronAPI.start(selected.join(','));
+  const lines = selected
+    .filter(id => urls[id])
+    .map(id => `${id}: ${urls[id]}`);
+  status.textContent = `Servers starting...\n${lines.join('\n')}`;
+  if (selected.includes('admin')) {
+    window.electronAPI.openExternal(urls.admin);
+  }
 });
 
 const log = document.getElementById('log');

--- a/cueit-macos/test/main.test.js
+++ b/cueit-macos/test/main.test.js
@@ -7,7 +7,8 @@ jest.unstable_mockModule('electron', () => {
   return {
     BrowserWindow: jest.fn().mockImplementation(() => ({ loadFile: jest.fn() })),
     ipcMain: { handle: jest.fn() },
-    app: { whenReady: () => Promise.resolve(), on: jest.fn() }
+    app: { whenReady: () => Promise.resolve(), on: jest.fn() },
+    shell: { openExternal: jest.fn() }
   };
 });
 

--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -17,10 +17,17 @@ npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
 
 APP_PATH="$APP_DIR/dist/CueIT-darwin-$arch/CueIT.app"
 
-mkdir -p "$APP_DIR/dist/CueIT-darwin-$arch/resources"
-cp -R cueit-api cueit-admin cueit-activate cueit-slack installers/start-all.sh "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
+RES_DIR="$APP_DIR/dist/CueIT-darwin-$arch/resources"
+mkdir -p "$RES_DIR/installers"
+cp -R cueit-api cueit-admin cueit-activate cueit-slack design "$RES_DIR/"
+cp installers/start-all.sh "$RES_DIR/installers/"
+# copy .env.example to .env so the launcher does not need to write inside
+# the application bundle on first run
+for pkg in cueit-api cueit-admin cueit-activate cueit-slack; do
+  cp "$pkg/.env.example" "$RES_DIR/$pkg/.env"
+done
 if [[ -f cert.pem && -f key.pem ]]; then
-  cp cert.pem key.pem "$APP_DIR/dist/CueIT-darwin-$arch/resources/"
+  cp cert.pem key.pem "$RES_DIR/"
 fi
 
 pkgbuild --root "$APP_PATH" --install-location /Applications \


### PR DESCRIPTION
## Summary
- show startup instructions in the macOS launcher
- expose `openExternal` in preload and handle it in the main process
- open the admin URL automatically when selected
- update tests for new electron mock

## Testing
- `npm test` in `cueit-macos`


------
https://chatgpt.com/codex/tasks/task_e_68686c2a5b0c8333a59f73ae31c340a6