### PR TITLE
Add CORS origins env support

### DIFF
--- a/cueit-api/.env.example
+++ b/cueit-api/.env.example
@@ -8,6 +8,7 @@ TLS_CERT_PATH=
 TLS_KEY_PATH=
 LOGO_URL=/logo.png
 SESSION_SECRET=change_this
+CORS_ORIGINS=https://localhost:5173
 SAML_ENTRY_POINT=https://idp.example.com/sso
 SAML_ISSUER=https://cueit.example.com
 SAML_CERT=-----BEGIN CERTIFICATE-----\n...

--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -18,7 +18,10 @@ import https from 'https';
 dotenv.config();
 
 const app = express();
-app.use(cors());
+const originList = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map((o) => o.trim())
+  : undefined;
+app.use(cors(originList ? { origin: originList } : undefined));
 app.use(express.json());
 
 const DISABLE_AUTH = process.env.DISABLE_AUTH === 'true' || process.env.NODE_ENV === 'test';

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -10,6 +10,7 @@ This project ships with sample environment files for each app. Copy these files 
    - Set `TLS_CERT_PATH` and `TLS_KEY_PATH` to local certificate files if you want to enable HTTPS.
    - Keep `ADMIN_URL` and other URLs as `https://localhost` when TLS is enabled, otherwise `http://localhost`.
    - `SESSION_SECRET` can be any string during local development.
+   - `CORS_ORIGINS` lists allowed origins as a comma-separated string.
 2. `cueit-admin/.env.example`
    - `VITE_API_URL` should match your local API URL.
    - Leave `VITE_LOGO_URL` and `VITE_ACTIVATE_URL` as provided or point to local resources.


### PR DESCRIPTION
## Summary
- allow configuring CORS origins for the API
- document the new env var

## Testing
- `npm install` within `cueit-api`
- `npm test` within `cueit-api`


------
https://chatgpt.com/codex/tasks/task_e_68689bd828e883338812fd7bbf7fd92f