### PR TITLE
Update session cookie settings

### DIFF
--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -39,6 +39,11 @@ if (!DISABLE_AUTH) {
       secret: process.env.SESSION_SECRET,
       resave: false,
       saveUninitialized: false,
+      cookie: {
+        httpOnly: true,
+        secure: process.env.NODE_ENV !== 'development',
+        sameSite: 'lax',
+      },
     })
   );
   app.use(passport.initialize());

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -42,5 +42,7 @@ When deploying to a live environment you must update each `.env` file with real 
 - Use HTTPS URLs for all services and SAML configuration.
 - Set a strong random `SESSION_SECRET` for the API.
 - Replace Slack tokens and signing secret with the real app credentials.
+- Set `NODE_ENV` to `production` so session cookies are sent with `httpOnly`,
+  `sameSite=lax` and `secure` enabled.
 
 Copy the respective `.env.example` file to `.env` in each folder, then edit the settings above before starting the services.


### PR DESCRIPTION
## Summary
- set secure cookie options in session middleware
- document NODE_ENV requirement for secure cookies

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868a7a7b2948333adc7b415dfd6b2c3