### PR TITLE
Add automatic log cleanup

### DIFF
--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -46,6 +46,7 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
   - `status` – filter by `email_status` value (`success` or `fail`).
 - `DELETE /api/logs/:id` – delete a log entry by numeric id.
 - `DELETE /api/logs` – remove all log entries.
+- Old logs older than 30 days are purged automatically (set `LOG_RETENTION_DAYS` to adjust).
 - `GET /api/config` – return configuration key/value pairs.
 - `PUT /api/config` – insert or update configuration values.
 

--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -101,4 +101,9 @@ db.deleteAllKiosks = (cb) => {
   db.run(`DELETE FROM kiosks`, cb);
 };
 
+db.purgeOldLogs = (days = 30, cb = () => {}) => {
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  db.run(`DELETE FROM logs WHERE timestamp < ?`, [cutoff], cb);
+};
+
 export default db;

--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -89,6 +89,19 @@ const PORT = process.env.API_PORT || 3000;
 const SLACK_URL = process.env.SLACK_WEBHOOK_URL;
 const CERT_PATH = process.env.TLS_CERT_PATH;
 const KEY_PATH = process.env.TLS_KEY_PATH;
+const LOG_RETENTION_DAYS = Number(process.env.LOG_RETENTION_DAYS || 30);
+
+if (process.env.DISABLE_CLEANUP !== 'true') {
+  const purge = () => {
+    db.purgeOldLogs(LOG_RETENTION_DAYS, (err) => {
+      if (err) {
+        console.error('Failed to purge old logs:', err.message);
+      }
+    });
+  };
+  purge();
+  setInterval(purge, 24 * 60 * 60 * 1000);
+}
 
 
 if (SLACK_URL) {

--- a/cueit-api/test/00_setup.js
+++ b/cueit-api/test/00_setup.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 if (!process.env.DISABLE_AUTH) {
   process.env.DISABLE_AUTH = 'true';
 }
+process.env.DISABLE_CLEANUP = 'true';
 process.env.SCIM_TOKEN = 'testtoken';
 process.env.KIOSK_TOKEN = 'kiosktoken';
 let app;

--- a/cueit-api/test/cleanup.test.js
+++ b/cueit-api/test/cleanup.test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import db from '../db.js';
+
+function resetLogs(cb) {
+  db.run('DELETE FROM logs', cb);
+}
+
+describe('log cleanup', function() {
+  beforeEach((done) => {
+    resetLogs(() => {
+      const old = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString();
+      const recent = new Date().toISOString();
+      db.run(
+        "INSERT INTO logs (ticket_id, name, email, title, system, urgency, timestamp, email_status) VALUES ('old', 'O', 'o@e', 't', 's', 'Low', ?, 'success')",
+        [old]
+      );
+      db.run(
+        "INSERT INTO logs (ticket_id, name, email, title, system, urgency, timestamp, email_status) VALUES ('new', 'N', 'n@e', 't2', 's', 'High', ?, 'success')",
+        [recent],
+        done
+      );
+    });
+  });
+
+  it('purges records older than 30 days', function(done) {
+    db.purgeOldLogs(30, (err) => {
+      if (err) return done(err);
+      db.all('SELECT ticket_id FROM logs', (err2, rows) => {
+        if (err2) return done(err2);
+        assert.strictEqual(rows.length, 1);
+        assert.strictEqual(rows[0].ticket_id, 'new');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- remove log entries older than 30 days with `purgeOldLogs`
- schedule daily cleanup in the API server
- document automatic purge and environment variable
- add unit test for log cleanup
- disable cleanup during tests

## Testing
- `npm install` within `cueit-api`
- `npm test` within `cueit-api`

------
https://chatgpt.com/codex/tasks/task_e_6868a94081e8833393cbaea328a42ce0