### PR TITLE
Enforce auth enabled in production

### DIFF
--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -34,7 +34,13 @@ const ticketLimiter = rateLimit({ windowMs: RATE_WINDOW, max: SUBMIT_TICKET_LIMI
 const apiLoginLimiter = rateLimit({ windowMs: RATE_WINDOW, max: API_LOGIN_LIMIT });
 const authLimiter = rateLimit({ windowMs: RATE_WINDOW, max: AUTH_LIMIT });
 
-const DISABLE_AUTH = process.env.DISABLE_AUTH === 'true' || process.env.NODE_ENV === 'test';
+if (process.env.DISABLE_AUTH === 'true' && process.env.NODE_ENV === 'production') {
+  console.error('DISABLE_AUTH cannot be true when NODE_ENV is production');
+  process.exit(1);
+}
+
+const DISABLE_AUTH = process.env.DISABLE_AUTH === 'true' ||
+  process.env.NODE_ENV === 'test';
 const SCIM_TOKEN = process.env.SCIM_TOKEN || '';
 const KIOSK_TOKEN = process.env.KIOSK_TOKEN || '';
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -50,5 +50,6 @@ When deploying to a live environment you must update each `.env` file with real 
 - Replace Slack tokens and signing secret with the real app credentials.
 - Set `NODE_ENV` to `production` so session cookies are sent with `httpOnly`,
   `sameSite=lax` and `secure` enabled.
+- Do not set `DISABLE_AUTH=true` when `NODE_ENV` is `production`.
 
 Copy the respective `.env.example` file to `.env` in each folder, then edit the settings above before starting the services.


### PR DESCRIPTION
## Summary
- exit on startup when `DISABLE_AUTH` is true in production
- document this behavior in the environment setup guide

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin`
- `npm test` in `cueit-activate`
- `npm test` in `cueit-slack`
- `npm run lint` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_6868b09677108333a38ae5e4e63e1918