### PR TITLE
Add feedback feature

### DIFF
--- a/cueit-admin/src/FeedbackPanel.jsx
+++ b/cueit-admin/src/FeedbackPanel.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import useApiError from './useApiError.js';
+
+export default function FeedbackPanel({ open }) {
+  const [items, setItems] = useState([]);
+  const api = import.meta.env.VITE_API_URL;
+  const handleApiError = useApiError();
+
+  useEffect(() => {
+    if (open) {
+      (async () => {
+        try {
+          const res = await axios.get(`${api}/api/feedback`);
+          setItems(res.data);
+        } catch (err) {
+          handleApiError(err, 'Failed to load feedback');
+        }
+      })();
+    }
+  }, [open, api, handleApiError]);
+
+  if (!open) return null;
+
+  return (
+    <div className="overflow-y-auto text-sm h-full">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="pb-2">Date</th>
+            <th className="pb-2">Name</th>
+            <th className="pb-2">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((f) => (
+            <tr key={f.id} className="border-t border-gray-700">
+              <td className="py-1 pr-2 text-xs">{new Date(f.timestamp).toLocaleString()}</td>
+              <td className="py-1 pr-2">{f.name}</td>
+              <td className="py-1 pr-2">{f.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -71,6 +71,23 @@ export default function Navbar({
                   <QuestionMarkCircleIcon className="h-5 w-5" />
                   Help
                 </button>
+                <button
+                  onClick={async () => {
+                    setShowMenu(false);
+                    const msg = window.prompt('Send feedback');
+                    if (msg) {
+                      try {
+                        await axios.post(`${api}/api/feedback`, { message: msg });
+                        window.alert('Feedback sent');
+                      } catch {
+                        window.alert('Failed to send');
+                      }
+                    }
+                  }}
+                  className="block w-full text-left px-4 py-2 flex items-center gap-2 hover:bg-gray-100"
+                >
+                  Send Feedback
+                </button>
                 <a
                   href={`${api}/logout`}
                   onClick={() => setShowMenu(false)}

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import UsersPanel from './UsersPanel.jsx';
+import FeedbackPanel from './FeedbackPanel.jsx';
 import useToast from './useToast.js';
 import useApiError from './useApiError.js';
 
@@ -82,7 +83,8 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
         <div className="flex mb-4 border-b border-gray-700 text-sm">
           <button className={`mr-4 pb-2 ${tab === 'general' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('general')}>General</button>
           <button className={`mr-4 pb-2 ${tab === 'kiosks' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('kiosks')}>Kiosks</button>
-          <button className={`pb-2 ${tab === 'users' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('users')}>Users</button>
+          <button className={`mr-4 pb-2 ${tab === 'users' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('users')}>Users</button>
+          <button className={`pb-2 ${tab === 'feedback' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('feedback')}>Feedback</button>
         </div>
         {tab === 'general' && (
           <div className="space-y-3 text-sm overflow-y-auto">
@@ -221,6 +223,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
           </div>
         )}
         {tab === 'users' && <UsersPanel open={open && tab === 'users'} />}
+        {tab === 'feedback' && <FeedbackPanel open={open && tab === 'feedback'} />}
       </div>
     </div>
   );

--- a/cueit-admin/src/__tests__/FeedbackPanel.test.jsx
+++ b/cueit-admin/src/__tests__/FeedbackPanel.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import axios from 'axios';
+import FeedbackPanel from '../FeedbackPanel.jsx';
+
+jest.mock('axios');
+
+test('loads feedback when open', async () => {
+  const items = [{ id: 1, name: 'Bob', message: 'Hi', timestamp: '2024-01-01T00:00:00Z' }];
+  axios.get.mockResolvedValueOnce({ data: items });
+  render(<FeedbackPanel open={true} />);
+  expect(await screen.findByText('Hi')).toBeInTheDocument();
+  expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/feedback'));
+});

--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -45,6 +45,15 @@ db.serialize(() => {
     )
   `);
 
+  db.run(`
+    CREATE TABLE IF NOT EXISTS feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT,
+      message TEXT,
+      timestamp TEXT
+    )
+  `);
+
   // add columns if database was created with an older schema
   function addColumnIfMissing(table, columnDef) {
     const columnName = columnDef.split(" ")[0];

--- a/cueit-api/index.js
+++ b/cueit-api/index.js
@@ -335,6 +335,27 @@ app.put("/api/config", ensureAuth, (req, res) => {
   });
 });
 
+app.post('/api/feedback', (req, res) => {
+  const { name = '', message } = req.body;
+  if (!message) return res.status(400).json({ error: 'Missing message' });
+  const timestamp = new Date().toISOString();
+  db.run(
+    `INSERT INTO feedback (name, message, timestamp) VALUES (?, ?, ?)`,
+    [name, message, timestamp],
+    function (err) {
+      if (err) return res.status(500).json({ error: 'DB error' });
+      res.json({ id: this.lastID });
+    }
+  );
+});
+
+app.get('/api/feedback', ensureAuth, (req, res) => {
+  db.all(`SELECT * FROM feedback ORDER BY timestamp DESC`, (err, rows) => {
+    if (err) return res.status(500).json({ error: 'DB error' });
+    res.json(rows);
+  });
+});
+
 app.post('/api/verify-password', ensureAuth, (req, res) => {
   const { password } = req.body;
   if (!password) return res.status(400).json({ error: 'Missing password' });

--- a/cueit-api/test/feedback.test.js
+++ b/cueit-api/test/feedback.test.js
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+const app = globalThis.app;
+
+beforeEach((done) => {
+  db.run('DELETE FROM feedback', done);
+});
+
+describe('Feedback API', function() {
+  it('stores feedback and returns id', async function() {
+    const res = await request(app)
+      .post('/api/feedback')
+      .send({ name: 'Alice', message: 'Great app' })
+      .expect(200);
+    assert.ok(res.body.id);
+
+    const list = await request(app).get('/api/feedback').expect(200);
+    assert.strictEqual(list.body.length, 1);
+    assert.strictEqual(list.body[0].name, 'Alice');
+    assert.strictEqual(list.body[0].message, 'Great app');
+  });
+
+  it('validates message', function() {
+    return request(app)
+      .post('/api/feedback')
+      .send({})
+      .expect(400);
+  });
+});
+

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/FeedbackFormView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/FeedbackFormView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct FeedbackFormView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var name = ""
+    @State private var message = ""
+    @State private var showError = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Name", text: $name)
+                TextEditor(text: $message)
+                    .frame(height: 120)
+                Button("Submit") { Task { await submit() } }
+            }
+            .navigationTitle("Feedback")
+            .alert("Failed to send", isPresented: $showError) {
+                Button("OK", role: .cancel) {}
+            }
+        }
+    }
+
+    @MainActor
+    func submit() async {
+        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/feedback") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = ["name": name, "message": message]
+        req.httpBody = try? JSONEncoder().encode(body)
+        do {
+            _ = try await URLSession.shared.data(for: req)
+            dismiss()
+        } catch {
+            showError = true
+        }
+    }
+}
+

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct LaunchView: View {
     @State private var showForm = false
     @State private var showAdmin = false
+    @State private var showFeedback = false
     @StateObject private var configService = ConfigService()
     @StateObject private var kioskService = KioskService.shared
     @State private var showAlert = false
@@ -68,6 +69,9 @@ struct LaunchView: View {
         .sheet(isPresented: $showAdmin) {
             AdminLoginView(configService: configService)
         }
+        .sheet(isPresented: $showFeedback) {
+            FeedbackFormView()
+        }
         .onAppear {
             Task { await configService.load() }
             TicketQueue.shared.retry()
@@ -106,6 +110,23 @@ struct LaunchView: View {
                 }
             },
             alignment: .topTrailing
+        )
+        .overlay(
+            HStack {
+                VStack {
+                    Spacer()
+                    Button(action: { showFeedback = true }) {
+                        Image(systemName: "ellipsis.bubble")
+                            .font(.title2)
+                            .foregroundColor(.black)
+                            .padding(.leading, Theme.Spacing.md)
+                            .padding(.bottom, Theme.Spacing.md)
+                    }
+                    .accessibilityLabel("Feedback")
+                }
+                Spacer()
+            },
+            alignment: .bottomLeading
         )
         .alert(alertMessage, isPresented: $showAlert) {
             Button("OK", role: .cancel) {}


### PR DESCRIPTION
## Summary
- add `feedback` table
- implement `/api/feedback` POST/GET endpoints
- display feedback in admin Settings
- add FeedbackPanel component and tests
- allow kiosk and admin UIs to submit feedback

## Testing
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin`


------
https://chatgpt.com/codex/tasks/task_e_6868b2de19b483339bc575078528c6d7