### PR TITLE
Add macOS uninstall and upgrade scripts

### DIFF
--- a/installers/uninstall-macos.sh
+++ b/installers/uninstall-macos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="/Applications/CueIT.app"
+
+if [[ -d "$APP_PATH" ]]; then
+  echo "Removing $APP_PATH..."
+  rm -rf "$APP_PATH"
+  echo "CueIT uninstalled."
+else
+  echo "CueIT not found at $APP_PATH."
+fi
+

--- a/installers/upgrade-macos.sh
+++ b/installers/upgrade-macos.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+PKG_ARG="${1:-}"
+
+if [[ -n "$PKG_ARG" && "$PKG_ARG" == *.pkg ]]; then
+  PKG_PATH="$PKG_ARG"
+else
+  VERSION="${PKG_ARG:-1.0.0}"
+  ./make-installer.sh "$VERSION"
+  PKG_PATH="../cueit-macos/CueIT-$VERSION.pkg"
+fi
+
+./uninstall-macos.sh
+
+if [[ -f "$PKG_PATH" ]]; then
+  sudo installer -pkg "$PKG_PATH" -target /
+else
+  echo "Package $PKG_PATH not found" >&2
+  exit 1
+fi
+


### PR DESCRIPTION
## Summary
- add helper to remove installed macOS app bundle
- add script to uninstall the old app then build or install a new package

## Testing
- `npm run lint` in `cueit-admin` *(fails: 'axios' is not defined)*
- `npm test` in `cueit-api`

------
https://chatgpt.com/codex/tasks/task_e_6868b884c81083339a184b8f3b2e9683