### PR TITLE
Update installer guidelines and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@
 ## Testing
 - Run `./setup.sh` to install Node.js, SQLite and all project dependencies if needed.
 - Each package contains its own test suite. Navigate to the package, run `npm install` (or `npm ci`) and then execute `npm test`.
+- Installer and upgrade scripts live in `installers/` and must include basic tests.
 
 ## Linting
-- Run the linter before committing changes: `npm run lint` inside each package that defines the script.
+- Run the linter before committing changes: `npm run lint` inside each package that defines the script. This also applies to any JavaScript tests added for installer-related packages.
 
 ## Repository Hygiene
 - Do not commit `node_modules`, build outputs or operating system files (such as `.DS_Store`).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Then build the AppImage:
 
 Mark the output file executable and run it to start the application.
 
+All installer and upgrade scripts live in `installers/` and should include basic tests to verify they work.
+
 ## Running Tests
 
 CueIT includes automated test suites for the backend API and the admin UI.
@@ -158,6 +160,7 @@ The API tests are written with Mocha and exercise the main Express endpoints.
 This suite uses Jest and React Testing Library to validate the UI.
 
 See the [contributor guide](AGENTS.md) for additional details.
+When adding JavaScript tests for installer scripts be sure to run `npm run lint` in the package you updated.
 
 ## Testing the API
 


### PR DESCRIPTION
## Summary
- document tests for installer/upgrade scripts
- note that `npm run lint` should be used with installer-related JS tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `cueit-api`
- `npm test` in `cueit-admin`
- `npm test` in `cueit-activate`
- `npm test` in `cueit-slack`
- `npm test` in `cueit-macos`


------
https://chatgpt.com/codex/tasks/task_e_6868b92c6b14833385660c4299763bce