### PR TITLE
Add installer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ dependencies if the `node_modules` directory is missing.
 ### macOS Launcher
 
 Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./installers/make-installer.sh` to build a `.pkg` installer, install it and launch **CueIT** from Applications.
+All installer scripts reside in the `installers/` directory.
+See [docs/installers.md](docs/installers.md) for detailed instructions.
+Run `./installers/uninstall-macos.sh` to remove the app and `./installers/upgrade-macos.sh` to rebuild and reinstall.
 During development you can run `npm start` inside the folder to launch Electron without packaging.
 
 The SwiftUI kiosk can only be built and run on macOS with Xcode installed.

--- a/cueit-macos/README.md
+++ b/cueit-macos/README.md
@@ -5,6 +5,7 @@ Electron launcher packaged for macOS.
 ## Building
 
 Run `../installers/make-installer.sh` to create `CueIT-<version>.pkg`. Install the package to `/Applications`.
+All installer scripts live in the repository's `installers/` directory. Use `../installers/uninstall-macos.sh` to remove the application. The helper script `../installers/upgrade-macos.sh` rebuilds a new package and reinstalls it.
 
 ## Setup
 

--- a/docs/installers.md
+++ b/docs/installers.md
@@ -1,0 +1,21 @@
+# Installer Scripts
+
+All installation utilities are kept in the `installers/` directory. They package the Electron launcher together with the API and web apps for each operating system.
+
+## macOS
+
+1. `./installers/make-installer.sh <version>` builds `CueIT-<version>.pkg` and installs it.
+2. `./installers/uninstall-macos.sh` removes the application from `/Applications`.
+3. `./installers/upgrade-macos.sh <version>` rebuilds the package (or accepts a `.pkg` path) and reinstalls it.
+
+## Windows
+
+1. Install Inno Setup, Node.js and npm.
+2. Run `./installers/make-windows-installer.ps1 -Version <version>` to create `CueIT-<version>.exe`.
+3. Execute the generated installer.
+
+## Linux
+
+1. Install `electron-installer-appimage` globally if missing.
+2. Run `./installers/make-linux-installer.sh <version>` to produce an AppImage.
+3. Mark the file executable and run it to start CueIT.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,7 @@ Use the installer script for your operating system:
 - **Windows** – run `./installers/make-windows-installer.ps1 -Version <version>` to build `CueIT-<version>.exe` and execute it.
 - **Linux** – run `./installers/make-linux-installer.sh <version>` to build an AppImage and launch it.
 
+All installer scripts are located under the `installers/` directory. On macOS you can remove the application with `./installers/uninstall-macos.sh` and upgrade it with `./installers/upgrade-macos.sh`. See [installers.md](installers.md) for more options.
 These scripts package the Electron launcher along with the API and web apps.
 
 ## 2. Configure


### PR DESCRIPTION
## Summary
- document macOS installer commands in main README
- note installer scripts in quickstart guide
- mention uninstall and upgrade scripts in macOS README
- add central documentation for all installer scripts

## Testing
- `npm run lint` *(fails: 'axios' is not defined)*
- `npm test` in cueit-admin
- `npm test` in cueit-activate
- `npm test` in cueit-api
- `npm test` in cueit-macos
- `npm test` in cueit-slack

------
https://chatgpt.com/codex/tasks/task_e_6868b92f58dc8333a2d01accb976e455