### PR TITLE
Add kiosk status management

### DIFF
--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -33,7 +33,13 @@ db.serialize(() => {
       version TEXT,
       active INTEGER DEFAULT 0,
       logoUrl TEXT,
-      bgUrl TEXT
+      bgUrl TEXT,
+      statusEnabled INTEGER DEFAULT 0,
+      currentStatus TEXT,
+      openMsg TEXT,
+      closedMsg TEXT,
+      errorMsg TEXT,
+      schedule TEXT
     )
   `);
 
@@ -76,6 +82,12 @@ db.serialize(() => {
   addColumnIfMissing('kiosks', 'active INTEGER DEFAULT 0');
   addColumnIfMissing('kiosks', 'logoUrl TEXT');
   addColumnIfMissing('kiosks', 'bgUrl TEXT');
+  addColumnIfMissing('kiosks', 'statusEnabled INTEGER DEFAULT 0');
+  addColumnIfMissing('kiosks', 'currentStatus TEXT');
+  addColumnIfMissing('kiosks', 'openMsg TEXT');
+  addColumnIfMissing('kiosks', 'closedMsg TEXT');
+  addColumnIfMissing('kiosks', 'errorMsg TEXT');
+  addColumnIfMissing('kiosks', 'schedule TEXT');
 
   // insert default config if not present
   const defaults = {
@@ -83,6 +95,9 @@ db.serialize(() => {
     faviconUrl: process.env.FAVICON_URL || '/vite.svg',
     welcomeMessage: 'Welcome to the Help Desk',
     helpMessage: 'Need to report an issue?',
+    statusOpenMsg: 'Open',
+    statusClosedMsg: 'Closed',
+    statusErrorMsg: 'Error',
     adminPassword: bcrypt.hashSync(process.env.ADMIN_PASSWORD || 'admin', 10),
     scimToken: process.env.SCIM_TOKEN || ''
   };

--- a/cueit-api/test/status.test.js
+++ b/cueit-api/test/status.test.js
@@ -1,0 +1,63 @@
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+const app = globalThis.app;
+const token = 'kiosktoken';
+
+function resetConfig(done) {
+  db.serialize(() => {
+    db.run("DELETE FROM config WHERE key IN ('statusOpenMsg','statusClosedMsg','statusErrorMsg')");
+    const stmt = db.prepare('INSERT INTO config (key, value) VALUES (?, ?)');
+    stmt.run('statusOpenMsg', 'Open');
+    stmt.run('statusClosedMsg', 'Closed');
+    stmt.run('statusErrorMsg', 'Error');
+    stmt.finalize(done);
+  });
+}
+
+beforeEach((done) => {
+  db.run('DELETE FROM kiosks', () => resetConfig(done));
+});
+
+describe('Kiosk status API', function() {
+  it('stores and retrieves kiosk status fields', async function() {
+    await request(app)
+      .post('/api/register-kiosk')
+      .send({ id: 'k1', token })
+      .expect(200);
+
+    let res = await request(app)
+      .get('/api/kiosks/k1/status')
+      .expect(200);
+    assert.strictEqual(res.body.statusEnabled, 0);
+
+    const payload = { statusEnabled: true, currentStatus: 'open', openMsg: 'Hi', schedule: { mon: '8-5' } };
+    await request(app)
+      .put('/api/kiosks/k1/status')
+      .send(payload)
+      .expect(200);
+
+    res = await request(app)
+      .get('/api/kiosks/k1/status')
+      .expect(200);
+    assert.strictEqual(res.body.statusEnabled, 1);
+    assert.strictEqual(res.body.currentStatus, 'open');
+    assert.strictEqual(res.body.openMsg, 'Hi');
+    assert.deepStrictEqual(JSON.parse(res.body.schedule), { mon: '8-5' });
+  });
+});
+
+describe('Global status config', function() {
+  it('PUT updates values and persists', async function() {
+    await request(app)
+      .put('/api/status-config')
+      .send({ statusOpenMsg: 'Yes', statusClosedMsg: 'No' })
+      .expect(200);
+
+    const res = await request(app)
+      .get('/api/status-config')
+      .expect(200);
+    assert.strictEqual(res.body.statusOpenMsg, 'Yes');
+    assert.strictEqual(res.body.statusClosedMsg, 'No');
+  });
+});


### PR DESCRIPTION
## Summary
- store kiosk status info in DB
- expose kiosk status and global messages APIs
- broadcast updates via events SSE
- test new persistence behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ba8a493c8333952f4856bbcae528