### PR TITLE
Fetch config in Slack modal and send ephemeral confirmations

### DIFF
--- a/cueit-slack/.env.example
+++ b/cueit-slack/.env.example
@@ -3,3 +3,4 @@ SLACK_BOT_TOKEN=xoxb-your-token
 API_URL=https://localhost:3000
 SLACK_PORT=3001
 JWT_SECRET=change_this_too
+VITE_ADMIN_URL=https://localhost:5173

--- a/cueit-slack/README.md
+++ b/cueit-slack/README.md
@@ -10,7 +10,12 @@ Slack slash command integration that lets users submit tickets directly from Sla
    - `SLACK_BOT_TOKEN`
    - `API_URL`
    - optional `SLACK_PORT` (defaults to `3001`)
+   - optional `VITE_ADMIN_URL` for a link in confirmation messages
 4. Start the service with `node index.js`.
+
+The modal fetches available systems and urgency levels from your backend via
+`/api/config`. Ensure `JWT_SECRET` matches the backend so this request is
+authorized.
 
 ## Local Testing
 Slack slash commands require a public HTTPS endpoint. While developing you can expose your local service using [ngrok](https://ngrok.com/):

--- a/cueit-slack/test/index.test.js
+++ b/cueit-slack/test/index.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 jest.unstable_mockModule('@slack/bolt', () => {
   const commandRegistry = {};
+  const viewRegistry = {};
   const startMock = jest.fn().mockResolvedValue();
 
   class App {
@@ -9,16 +10,39 @@ jest.unstable_mockModule('@slack/bolt', () => {
     command(name, handler) {
       commandRegistry[name] = handler;
     }
-    view() {}
+    view(id, handler) {
+      viewRegistry[id] = handler;
+    }
     start() {
       return startMock();
     }
   }
 
-  return { App, __commandRegistry: commandRegistry, __startMock: startMock };
+  return {
+    App,
+    __commandRegistry: commandRegistry,
+    __viewRegistry: viewRegistry,
+    __startMock: startMock,
+  };
 });
 
-const { __commandRegistry } = await import('@slack/bolt');
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+const { __commandRegistry, __viewRegistry } = await import('@slack/bolt');
+const axios = (await import('axios')).default;
+
+beforeEach(() => {
+  process.env.API_URL = 'http://localhost';
+  process.env.JWT_SECRET = 'secret';
+  delete process.env.VITE_ADMIN_URL;
+  axios.get.mockReset();
+  axios.post.mockReset();
+});
 await import('..');
 
 describe('Slack command handler', () => {
@@ -38,6 +62,61 @@ describe('Slack command handler', () => {
         trigger_id: '123',
         view: expect.objectContaining({ type: 'modal' }),
       })
+    );
+  });
+
+  it('loads options from backend', async () => {
+    axios.get.mockResolvedValue({
+      data: { systems: ['Sys1', 'Sys2'], urgencyLevels: ['High', 'Low'] },
+    });
+    const handler = __commandRegistry['/new-ticket'];
+    const ack = jest.fn().mockResolvedValue();
+    const open = jest.fn().mockResolvedValue();
+    const client = { views: { open } };
+    const body = { trigger_id: 't', channel_id: 'C1', user: { id: 'U1' } };
+
+    await handler({ ack, body, client });
+
+    const view = open.mock.calls[0][0].view;
+    const systemBlock = view.blocks.find((b) => b.block_id === 'system');
+    const urgencyBlock = view.blocks.find((b) => b.block_id === 'urgency');
+    expect(systemBlock.element.options.map((o) => o.value)).toEqual([
+      'Sys1',
+      'Sys2',
+    ]);
+    expect(urgencyBlock.element.options.map((o) => o.value)).toEqual([
+      'High',
+      'Low',
+    ]);
+  });
+
+  it('sends ephemeral confirmation', async () => {
+    const handler = __viewRegistry['ticket_submit'];
+    axios.post.mockResolvedValue({
+      data: { ticketId: '42', emailStatus: 'success' },
+    });
+    const ack = jest.fn().mockResolvedValue();
+    const postEphemeral = jest.fn().mockResolvedValue();
+    const client = { chat: { postEphemeral } };
+    const view = {
+      state: {
+        values: {
+          name: { value: { value: 'A' } },
+          email: { value: { value: 'a@b.com' } },
+          title: { value: { value: 'T' } },
+          system: { value: { selected_option: { value: 'Sys1' } } },
+          urgency: { value: { selected_option: { value: 'High' } } },
+          description: { value: { value: '' } },
+        },
+      },
+      private_metadata: 'C1',
+    };
+    const body = { user: { id: 'U1' } };
+
+    await handler({ ack, body, view, client });
+
+    expect(postEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', user: 'U1' })
     );
   });
 });


### PR DESCRIPTION
## Summary
- load system/urgency options for the Slack modal from `/api/config`
- post formatted ephemeral confirmations that link to the admin UI when available
- test Slack option loading and ephemeral delivery
- document the new `VITE_ADMIN_URL` option for the Slack service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868bc3ba68c8333904e39812986cbab