### PR TITLE
Add status service with banner

### DIFF
--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/StatusService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/StatusService.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Combine
+
+struct StatusUpdate: Codable {
+    let status: String
+    let message: String
+}
+
+class StatusService: ObservableObject {
+    static let shared = StatusService()
+    @Published var latest: StatusUpdate?
+
+    private var task: Task<Void, Never>?
+
+    private init() {
+        loadCached()
+        connect()
+    }
+
+    private func loadCached() {
+        if let data = UserDefaults.standard.data(forKey: "lastStatus"),
+           let update = try? JSONDecoder().decode(StatusUpdate.self, from: data) {
+            latest = update
+        }
+    }
+
+    private func cacheCurrent() {
+        if let update = latest,
+           let data = try? JSONEncoder().encode(update) {
+            UserDefaults.standard.set(data, forKey: "lastStatus")
+        }
+    }
+
+    private func connect() {
+        task?.cancel()
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/events") else { return }
+        task = Task {
+            do {
+                let (bytes, _) = try await URLSession.shared.bytes(from: url)
+                for try await line in bytes.lines {
+                    if line.hasPrefix("data: ") {
+                        let json = line.dropFirst(6)
+                        if let data = json.data(using: .utf8),
+                           let update = try? JSONDecoder().decode(StatusUpdate.self, from: data) {
+                            await MainActor.run {
+                                self.latest = update
+                                self.cacheCurrent()
+                            }
+                        }
+                    }
+                }
+            } catch {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                self.connect()
+            }
+        }
+    }
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Theme.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Theme.swift
@@ -7,6 +7,9 @@ struct Theme {
         static let accent = Color(hex: "#F97316")
         static let base = Color(hex: "#ffffff")
         static let content = Color(hex: "#1f2937")
+        static let green = Color.green
+        static let red = Color.red
+        static let yellow = Color.yellow
     }
 
     struct Spacing {

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -14,6 +14,7 @@ struct LaunchView: View {
     @StateObject private var configService = ConfigService()
     @StateObject private var kioskService = KioskService.shared
     @StateObject private var notificationService = NotificationService.shared
+    @StateObject private var statusService = StatusService.shared
     @State private var showAlert = false
     @State private var alertMessage = ""
 
@@ -130,7 +131,14 @@ struct LaunchView: View {
             alignment: .bottomLeading
         )
         .overlay(
-            Group {
+            VStack(spacing: 0) {
+                if let status = statusService.latest {
+                    Text(status.message)
+                        .padding(8)
+                        .frame(maxWidth: .infinity)
+                        .background(color(for: status.status))
+                        .foregroundColor(.black)
+                }
                 if let note = notificationService.latest {
                     Text(note.message)
                         .padding(8)
@@ -149,8 +157,8 @@ struct LaunchView: View {
 
 func color(for level: String) -> Color {
     switch level {
-    case "warning": return .yellow
-    case "error": return .red
-    default: return .green
+    case "warning": return Theme.Colors.yellow
+    case "error": return Theme.Colors.red
+    default: return Theme.Colors.green
     }
 }

--- a/cueit-kiosk/CueIT KioskTests/StatusServiceTests.swift
+++ b/cueit-kiosk/CueIT KioskTests/StatusServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CueIT_Kiosk
+
+final class StatusServiceTests: XCTestCase {
+    func testStatusPersistsAcrossInstances() {
+        UserDefaults.standard.removeObject(forKey: "lastStatus")
+        let update = StatusUpdate(status: "warning", message: "Heads up")
+        let data = try! JSONEncoder().encode(update)
+        UserDefaults.standard.set(data, forKey: "lastStatus")
+
+        let service = StatusService.shared
+        XCTAssertEqual(service.latest?.status, "warning")
+        XCTAssertEqual(service.latest?.message, "Heads up")
+    }
+
+    func testBannerColorMapping() {
+        XCTAssertEqual(color(for: "warning"), Theme.Colors.yellow)
+        XCTAssertEqual(color(for: "error"), Theme.Colors.red)
+        XCTAssertEqual(color(for: "other"), Theme.Colors.green)
+    }
+}

--- a/design/theme.js
+++ b/design/theme.js
@@ -7,7 +7,10 @@ export const colors = {
   surface: '#f9fafb',
   logoShadow: '#646cffaa',
   reactShadow: '#61dafbaa',
-  muted: '#888'
+  muted: '#888',
+  green: '#22c55e',
+  red: '#ef4444',
+  yellow: '#facc15'
 };
 
 export const fonts = {


### PR DESCRIPTION
## Summary
- implement `StatusService` streaming `/api/events`
- cache last status in `UserDefaults`
- expose green/red/yellow in `Theme`
- show status banner in `LaunchView`
- document color tokens in `design/theme.js`
- add `StatusServiceTests`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild ... test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c5f0b80c8333893712e8e58a051e