### PR TITLE
Add status management tab

### DIFF
--- a/cueit-admin/src/__tests__/StatusPanel.test.jsx
+++ b/cueit-admin/src/__tests__/StatusPanel.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import SettingsPanel from '../SettingsPanel.jsx';
+
+jest.mock('axios');
+
+const status = {
+  id: 'k1',
+  statusEnabled: 0,
+  currentStatus: 'open',
+  openMsg: 'Hi',
+  closedMsg: 'Bye',
+  errorMsg: 'Err',
+  schedule: '{}',
+};
+
+test('saves status via axios', async () => {
+  axios.get.mockResolvedValueOnce({ data: [status] });
+  axios.put.mockResolvedValue({});
+  render(<SettingsPanel open={true} onClose={() => {}} config={{}} setConfig={() => {}} />);
+  await userEvent.click(screen.getByText('Status'));
+  const input = await screen.findByLabelText('Open Message');
+  await userEvent.clear(input);
+  await userEvent.type(input, 'Hello');
+  await userEvent.click(screen.getByText('Save'));
+  expect(axios.put).toHaveBeenCalledWith(
+    expect.stringContaining('/api/kiosks/k1/status'),
+    expect.objectContaining({ openMsg: 'Hello' })
+  );
+});


### PR DESCRIPTION
## Summary
- support editing kiosk status in SettingsPanel
- test status form interactions

## Testing
- `npm test` in `cueit-admin`
- `npm run lint` in `cueit-admin`

------
https://chatgpt.com/codex/tasks/task_e_6868c61705508333905c29e399363c62