### PR TITLE
Add JWT login flow and user password editing

### DIFF
--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo, useRef, useCallback } from 'react';
 import axios from 'axios';
 import Navbar from './Navbar';
 import SettingsPanel from './SettingsPanel';
+import LoginPage from './LoginPage.jsx';
 import useToast from './useToast.js';
 import useApiError from './useApiError.js';
 import './App.css';
@@ -10,6 +11,9 @@ const urgencyPriority = { Urgent: 3, High: 2, Medium: 1, Low: 0 };
 
 function App() {
   const [logs, setLogs] = useState([]);
+  const [page, setPage] = useState(
+    window.location.hash === '#/login' ? 'login' : 'app'
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [search, setSearch] = useState('');
@@ -25,6 +29,29 @@ function App() {
   const [apiConnected, setApiConnected] = useState(true);
   const prevConnectedRef = useRef(true);
   const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const onHash = () => {
+      setPage(window.location.hash === '#/login' ? 'login' : 'app');
+    };
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
+  }, []);
+
+  useEffect(() => {
+    const t = localStorage.getItem('token');
+    if (t) {
+      axios.defaults.headers.common.Authorization = `Bearer ${t}`;
+    }
+  }, []);
+
+  const handleLogin = (token) => {
+    localStorage.setItem('token', token);
+    axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+    window.location.hash = '';
+    window.location.reload();
+  };
+
 
   const filteredLogs = useMemo(() => {
     const searchLower = search.toLowerCase();
@@ -150,6 +177,10 @@ function App() {
       link.href = config.faviconUrl;
     }
   }, [config.faviconUrl]);
+
+  if (page === 'login') {
+    return <LoginPage onSuccess={handleLogin} />;
+  }
 
   return (
     <>

--- a/cueit-admin/src/LoginPage.jsx
+++ b/cueit-admin/src/LoginPage.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { colors } from './theme.js';
+
+export default function LoginPage({ onSuccess }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const api = import.meta.env.VITE_API_URL;
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await axios.post(`${api}/api/login`, { email, password });
+      onSuccess(res.data.token);
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
+      <form onSubmit={submit} className="bg-gray-800 p-6 rounded space-y-4 w-80">
+        <h1 className="text-xl mb-2 text-center">Admin Login</h1>
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full px-3 py-2 rounded text-black"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full px-3 py-2 rounded text-black"
+          required
+        />
+        <button
+          type="submit"
+          style={{ backgroundColor: colors.primary }}
+          className="w-full py-2 rounded mt-2"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/cueit-admin/src/Navbar.jsx
+++ b/cueit-admin/src/Navbar.jsx
@@ -90,8 +90,12 @@ export default function Navbar({
                   Send Feedback
                 </button>
                 <a
-                  href={`${api}/logout`}
-                  onClick={() => setShowMenu(false)}
+                  href="#/login"
+                  onClick={() => {
+                    setShowMenu(false);
+                    localStorage.removeItem('token');
+                    delete axios.defaults.headers.common.Authorization;
+                  }}
                   className="block w-full text-left px-4 py-2 flex items-center gap-2 hover:bg-gray-100"
                 >
                   Logout

--- a/cueit-admin/src/UsersPanel.jsx
+++ b/cueit-admin/src/UsersPanel.jsx
@@ -12,7 +12,7 @@ export default function UsersPanel({ open }) {
       (async () => {
         try {
           const res = await axios.get(`${api}/api/users`);
-          setUsers(res.data);
+          setUsers(res.data.map((u) => ({ ...u, password: '' })));
         } catch (err) {
           handleApiError(err, 'Failed to load users');
         }
@@ -23,7 +23,7 @@ export default function UsersPanel({ open }) {
   const addUser = async () => {
     try {
       const res = await axios.post(`${api}/api/users`, { name: '', email: '' });
-      setUsers(prev => [...prev, { id: res.data.id, name: '', email: '' }]);
+      setUsers((prev) => [...prev, { id: res.data.id, name: '', email: '', password: '' }]);
     } catch (err) {
       handleApiError(err, 'Failed to add user');
     }
@@ -34,7 +34,9 @@ export default function UsersPanel({ open }) {
       await axios.put(`${api}/api/users/${u.id}`, {
         name: u.name,
         email: u.email,
+        password: u.password || undefined,
       });
+      setUsers((us) => us.map((x) => (x.id === u.id ? { ...x, password: '' } : x)));
     } catch (err) {
       handleApiError(err, 'Failed to save user');
     }
@@ -59,6 +61,7 @@ export default function UsersPanel({ open }) {
           <tr className="text-left">
             <th className="pb-2">Name</th>
             <th className="pb-2">Email</th>
+            <th className="pb-2">Password</th>
             <th className="pb-2"></th>
           </tr>
         </thead>
@@ -91,6 +94,21 @@ export default function UsersPanel({ open }) {
                     )
                   }
                   className="w-40 px-1 text-black rounded"
+                />
+              </td>
+              <td className="py-1 pr-2">
+                <input
+                  type="password"
+                  placeholder="new password"
+                  value={u.password || ''}
+                  onChange={(e) =>
+                    setUsers((us) =>
+                      us.map((x) =>
+                        x.id === u.id ? { ...x, password: e.target.value } : x
+                      )
+                    )
+                  }
+                  className="w-32 px-1 text-black rounded"
                 />
               </td>
               <td className="py-1 space-x-1">

--- a/cueit-admin/src/useApiError.js
+++ b/cueit-admin/src/useApiError.js
@@ -1,17 +1,19 @@
 import { useCallback } from 'react';
+import axios from 'axios';
 import useToast from './useToast.js';
 
 export default function useApiError() {
-  const api = import.meta.env.VITE_API_URL;
   const toast = useToast();
   return useCallback(
     (err, msg) => {
       if (err.response && err.response.status === 401) {
-        window.location.href = `${api}/login`;
+        localStorage.removeItem('token');
+        delete axios.defaults.headers.common.Authorization;
+        window.location.hash = '#/login';
       } else if (msg) {
         toast(msg, 'error');
       }
     },
-    [api, toast]
+    [toast]
   );
 }


### PR DESCRIPTION
## Summary
- add a `LoginPage` component for JWT authentication
- redirect unauthenticated API calls to the new login page
- persist JWT token and update logout handling
- allow editing passwords in user management panel

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c7567d3083339b2243b3965e3fa4