### PR TITLE
Add in-app kiosk activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,13 @@ the `kiosks` table with `active` set to `0` (inactive). A kiosk cannot submit
 tickets until it is activated.
 
 An administrator can toggle the `active` flag from the **Kiosks** tab in the
-admin UI or by visiting the separate activation page provided by the
-`cueit-activate` app. Both interfaces call
-`PUT /api/kiosks/:id/active` to update the flag. The iPad app periodically
-fetches its configuration from `/api/kiosks/:id`; if `active` is `0` it shows an
-activation required message instead of the ticket form.
-When `VITE_ADMIN_URL` is set, the activation page shows a link back to the admin
-UI for convenience.
+admin UI, from the separate activation page provided by the
+`cueit-activate` app, or directly from the iPad kiosk. All three interfaces call
+`PUT /api/kiosks/:id/active` to update the flag. When a kiosk is inactive the
+app displays an activation screen showing the API URL and kiosk ID. Tapping the
+**Activate** button sends the request to enable the kiosk.
+When `VITE_ADMIN_URL` is set, the web activation page shows a link back to the
+admin UI for convenience.
 
 To remotely disable a kiosk open the **Kiosks** tab in the admin UI and toggle
 the active switch to the off position. You can also send a `PUT` request to

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Services/KioskService.swift
@@ -77,6 +77,24 @@ class KioskService: ObservableObject {
         }
     }
 
+    @MainActor
+    func activate() async -> Bool {
+        guard let url = URL(string: "\(APIConfig.baseURL)/api/kiosks/\(id)/active") else { return false }
+        var req = URLRequest(url: url)
+        req.httpMethod = "PUT"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONEncoder().encode(["active": true])
+        do {
+            _ = try await URLSession.shared.data(for: req)
+            state = .active
+            activationError = false
+            return true
+        } catch {
+            activationError = true
+            return false
+        }
+    }
+
     private func pollAndScheduleNext() async {
         await checkActive()
         scheduleNextPoll()

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/ActivationView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/ActivationView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ActivationView: View {
+    @State private var activating = false
+    @State private var error = false
+    @StateObject private var kioskService = KioskService.shared
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "wifi")
+                .font(.system(size: 64))
+                .foregroundColor(Theme.Colors.accent)
+            Text("Kiosk Setup")
+                .font(.title)
+                .fontWeight(.semibold)
+            Text("API: \(APIConfig.baseURL)")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.Spacing.md)
+            Text("ID: \(kioskService.id)")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+            if activating {
+                ProgressView()
+            } else {
+                Button("Activate") { Task { await activate() } }
+                    .padding(Theme.Spacing.sm)
+                    .background(Theme.Colors.primary)
+                    .foregroundColor(Theme.Colors.base)
+                    .cornerRadius(8)
+            }
+            if error {
+                Text("Activation failed")
+                    .foregroundColor(Theme.Colors.accent)
+            }
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.Colors.base.ignoresSafeArea())
+    }
+
+    @MainActor
+    private func activate() async {
+        activating = true
+        error = false
+        let success = await kioskService.activate()
+        activating = false
+        error = !success
+    }
+}

--- a/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
+++ b/cueit-kiosk/CueIT Kiosk/CueIT Kiosk/Views/LaunchView.swift
@@ -22,7 +22,7 @@ struct LaunchView: View {
         ZStack {
             switch kioskService.state {
             case .inactive:
-                PendingActivationView()
+                ActivationView()
             case .error:
                 ActivationErrorView { Task { await kioskService.checkActive() } }
             default:


### PR DESCRIPTION
## Summary
- add ActivationView to kiosk
- implement activation request in KioskService
- show ActivationView when inactive
- document new activation workflow in README

## Testing
- `npm test` in `cueit-activate`
- `npm test` in `cueit-admin`
- `npm test` in `cueit-api` *(fails: token missing)*
- `npm test` in `cueit-slack`
- `npm test` in `cueit-macos`


------
https://chatgpt.com/codex/tasks/task_e_6868c731235c8333a1423d35f063b89e