### PR TITLE
Add loading status indicators to activation page

### DIFF
--- a/cueit-activate/README.md
+++ b/cueit-activate/README.md
@@ -7,6 +7,11 @@ A minimal React page for activating kiosks.
 2. Copy `.env.example` to `.env` and set `VITE_API_URL`. Optionally set `VITE_ADMIN_URL` to the admin interface so a link appears on the page.
 3. Start the dev server with `npm run dev`.
 
+### UI feedback
+
+When activating a kiosk, the page now displays a yellow "Loading..." message
+while the request is pending. On success the confirmation text turns green and on failure it appears in red.
+
 ### Theme
 
 This page also consumes the shared design tokens in `../../design/theme.js` via

--- a/cueit-activate/src/App.jsx
+++ b/cueit-activate/src/App.jsx
@@ -5,16 +5,21 @@ import theme from '../../design/theme.js';
 export default function App() {
   const [kioskId, setKioskId] = useState('');
   const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('idle');
   const adminUrl = import.meta.env.VITE_ADMIN_URL;
 
   const activate = async () => {
     if (!kioskId) return;
+    setStatus('loading');
+    setMessage('');
     try {
       const api = import.meta.env.VITE_API_URL;
       await axios.put(`${api}/api/kiosks/${kioskId}/active`, { active: true });
       setMessage('Kiosk activated');
+      setStatus('success');
     } catch (err) {
       setMessage('Activation failed');
+      setStatus('error');
     }
   };
 
@@ -55,7 +60,29 @@ export default function App() {
       >
         Activate
       </button>
-      {message && <p style={{ marginTop: theme.spacing.md }}>{message}</p>}
+      {status === 'loading' && (
+        <p
+          role="status"
+          style={{ color: theme.colors.yellow, marginTop: theme.spacing.md }}
+        >
+          Loading...
+        </p>
+      )}
+      {message && status !== 'loading' && (
+        <p
+          style={{
+            marginTop: theme.spacing.md,
+            color:
+              status === 'success'
+                ? theme.colors.green
+                : status === 'error'
+                  ? theme.colors.red
+                  : theme.colors.content,
+          }}
+        >
+          {message}
+        </p>
+      )}
       {adminUrl && (
         <a
           href={adminUrl}

--- a/cueit-activate/src/__tests__/App.test.jsx
+++ b/cueit-activate/src/__tests__/App.test.jsx
@@ -28,6 +28,21 @@ test('shows error message when activation fails', async () => {
   expect(await screen.findByText('Activation failed')).toBeInTheDocument();
 });
 
+test('shows loading indicator while request is pending', async () => {
+  let resolveApi;
+  axios.put.mockImplementation(
+    () => new Promise((res) => {
+      resolveApi = res;
+    })
+  );
+  render(<App />);
+  await userEvent.type(screen.getByPlaceholderText('Enter kiosk ID'), '7');
+  userEvent.click(screen.getByText('Activate'));
+  expect(await screen.findByRole('status')).toHaveTextContent('Loading...');
+  resolveApi({});
+  expect(await screen.findByText('Kiosk activated')).toBeInTheDocument();
+});
+
 test('renders admin link when env var is set', () => {
   process.env.VITE_ADMIN_URL = 'http://admin';
   render(<App />);


### PR DESCRIPTION
## Summary
- add loading spinner and success/error colors to activation page
- add tests for new loading state
- document UI feedback in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868cb5d10e08333aa6e51719cfd6dd9