### PR TITLE
Create universal macOS package

### DIFF
--- a/cueit-macos/README.md
+++ b/cueit-macos/README.md
@@ -4,7 +4,7 @@ Electron launcher packaged for macOS.
 
 ## Building
 
-Run `../installers/make-installer.sh` to create `CueIT-<version>.pkg`. Install the package to `/Applications`.
+Run `../installers/make-installer.sh` to create `CueIT-<version>.pkg`. The installer now builds a **universal** package compatible with Apple Silicon and Intel Macs. Install the package to `/Applications`.
 All installer scripts live in the repository's `installers/` directory. Use `../installers/uninstall-macos.sh` to remove the application. The helper script `../installers/upgrade-macos.sh` rebuilds a new package and reinstalls it.
 
 ## Setup

--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -6,10 +6,7 @@ cd "$SCRIPT_DIR/.."
 APP_DIR="cueit-macos"
 VERSION="${1:-1.0.0}"
 
-arch=$(uname -m)
-if [[ "$arch" == "x86_64" ]]; then
-  arch="x64"
-fi
+arch="universal"
 
 npm --prefix "$APP_DIR" install
 npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \


### PR DESCRIPTION
## Summary
- generate a universal macOS build in `make-installer.sh`
- mention universal compatibility in the macOS README

## Testing
- `npm test --silent` in `cueit-macos`

------
https://chatgpt.com/codex/tasks/task_e_6868cff3ac64833389e45ab87de32bc0