### PR TITLE
Add embedded admin UI window

### DIFF
--- a/cueit-macos/index.html
+++ b/cueit-macos/index.html
@@ -18,6 +18,9 @@
       width: 100%;
       height: 300px;
     }
+    #launch-admin {
+      margin-left: var(--spacing-sm);
+    }
   </style>
 </head>
 <body>
@@ -27,6 +30,7 @@
     <label><input type="checkbox" id="activate" /> activate</label>
     <label><input type="checkbox" id="slack" /> slack</label>
     <button id="start">Start</button>
+    <button id="launch-admin">Admin UI</button>
   </div>
   <pre id="status"></pre>
   <textarea id="log" readonly></textarea>

--- a/cueit-macos/main.js
+++ b/cueit-macos/main.js
@@ -12,6 +12,7 @@ const packages = {
   slack: 'cueit-slack'
 };
 let win;
+let adminWin;
 
 async function ensureEnvFiles(baseDir = path.join(__dirname, '..')) {
   let created = false;
@@ -35,6 +36,20 @@ function createWindow(showSetup) {
     webPreferences: { preload: path.join(__dirname, 'preload.js') }
   });
   win.loadFile(showSetup ? 'setup.html' : 'index.html');
+}
+
+function createAdminWindow() {
+  if (adminWin) {
+    adminWin.focus();
+    return;
+  }
+  adminWin = new BrowserWindow({
+    width: 1000,
+    height: 700,
+    webPreferences: { preload: path.join(__dirname, 'preload.js') }
+  });
+  adminWin.loadFile(path.join(__dirname, '..', 'cueit-admin', 'dist', 'index.html'));
+  adminWin.on('closed', () => { adminWin = null; });
 }
 
 async function start() {
@@ -80,4 +95,8 @@ ipcMain.handle('open-external', (_e, url) => {
   shell.openExternal(url);
 });
 
-export { ensureEnvFiles, createWindow, start };
+ipcMain.handle('open-admin', () => {
+  createAdminWindow();
+});
+
+export { ensureEnvFiles, createWindow, start, createAdminWindow };

--- a/cueit-macos/preload.js
+++ b/cueit-macos/preload.js
@@ -5,5 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onLog: handler => ipcRenderer.on('log', (_e, data) => handler(data)),
   readEnvs: () => ipcRenderer.invoke('read-envs'),
   writeEnvs: envs => ipcRenderer.invoke('write-envs', envs),
-  openExternal: url => ipcRenderer.invoke('open-external', url)
+  openExternal: url => ipcRenderer.invoke('open-external', url),
+  openAdmin: () => ipcRenderer.invoke('open-admin')
 });

--- a/cueit-macos/renderer.js
+++ b/cueit-macos/renderer.js
@@ -19,8 +19,12 @@ document.getElementById('start').addEventListener('click', () => {
     .map(id => `${id}: ${urls[id]}`);
   status.textContent = `Servers starting...\n${lines.join('\n')}`;
   if (selected.includes('admin')) {
-    window.electronAPI.openExternal(urls.admin);
+    window.electronAPI.openAdmin();
   }
+});
+
+document.getElementById('launch-admin').addEventListener('click', () => {
+  window.electronAPI.openAdmin();
 });
 
 const log = document.getElementById('log');

--- a/cueit-macos/setup.js
+++ b/cueit-macos/setup.js
@@ -20,5 +20,6 @@ saveButton.addEventListener('click', async () => {
   const data = {};
   envsDiv.querySelectorAll('textarea').forEach(t => { data[t.id] = t.value; });
   await window.electronAPI.writeEnvs(data);
+  await window.electronAPI.openAdmin();
   window.location = 'index.html';
 });

--- a/cueit-macos/test/main.test.js
+++ b/cueit-macos/test/main.test.js
@@ -5,14 +5,17 @@ import path from 'path';
 
 jest.unstable_mockModule('electron', () => {
   return {
-    BrowserWindow: jest.fn().mockImplementation(() => ({ loadFile: jest.fn() })),
+    BrowserWindow: jest.fn().mockImplementation(() => ({
+      loadFile: jest.fn(),
+      on: jest.fn()
+    })),
     ipcMain: { handle: jest.fn() },
     app: { whenReady: () => Promise.resolve(), on: jest.fn() },
     shell: { openExternal: jest.fn() }
   };
 });
 
-const { ensureEnvFiles, createWindow } = await import('../main.js');
+const { ensureEnvFiles, createWindow, createAdminWindow } = await import('../main.js');
 const { BrowserWindow } = await import('electron');
 
 function makePkgDir(base, name) {
@@ -58,6 +61,16 @@ describe('createWindow', () => {
     createWindow(false);
     const win = BrowserWindow.mock.results[1].value;
     expect(win.loadFile).toHaveBeenCalledWith('index.html');
+  });
+});
+
+describe('createAdminWindow', () => {
+  test('loads admin ui', () => {
+    const callCount = BrowserWindow.mock.results.length;
+    createAdminWindow();
+    const win = BrowserWindow.mock.results[callCount].value;
+    const arg = win.loadFile.mock.calls[0][0];
+    expect(arg).toMatch(/cueit-admin\/dist\/index\.html$/);
   });
 });
 

--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -9,6 +9,8 @@ VERSION="${1:-1.0.0}"
 arch="universal"
 
 npm --prefix "$APP_DIR" install
+npm --prefix cueit-admin install
+npm --prefix cueit-admin run build
 npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
   --platform=darwin --arch="$arch" --out "$APP_DIR/dist" --overwrite
 

--- a/installers/make-linux-installer.sh
+++ b/installers/make-linux-installer.sh
@@ -7,6 +7,8 @@ APP_DIR="cueit-macos"
 VERSION="${1:-1.0.0}"
 
 npm --prefix "$APP_DIR" install
+npm --prefix cueit-admin install
+npm --prefix cueit-admin run build
 npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
   --platform=linux --out "$APP_DIR/dist" --overwrite
 

--- a/installers/make-windows-installer.ps1
+++ b/installers/make-windows-installer.ps1
@@ -8,6 +8,8 @@ Set-Location (Join-Path $PSScriptRoot '..')
 $AppDir = 'cueit-macos'
 
 npm --prefix $AppDir install
+npm --prefix cueit-admin install
+npm --prefix cueit-admin run build
 npx --prefix $AppDir electron-packager $AppDir CueIT `
   --platform=win32 --arch=x64 --out "$AppDir/dist" --overwrite
 


### PR DESCRIPTION
## Summary
- add ability to open the built admin UI from the macOS launcher
- run `npm run build` for cueit-admin when packaging installers
- provide launcher button to open admin UI
- open admin UI after setup completes
- reuse design tokens for consistent styling
- test createAdminWindow logic

## Testing
- `./installers/setup.sh`
- `cd cueit-macos && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868d0cff81483338746fa2933b33777