### PR TITLE
Fix theme defaults for Tailwind build

### DIFF
--- a/cueit-admin/src/index.css
+++ b/cueit-admin/src/index.css
@@ -6,15 +6,15 @@
 
 :root {
   font-family: 'Inter', system-ui, sans-serif;
-  background-color: theme('colors.surface');
-  color: theme('colors.content');
+  background-color: theme('colors.surface', '#f9fafb');
+  color: theme('colors.content', '#1f2937');
   line-height: 1.5;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --logo-shadow: theme('colors.logoShadow');
-  --react-shadow: theme('colors.reactShadow');
-  --muted: theme('colors.muted');
+  --logo-shadow: theme('colors.logoShadow', '#646cffaa');
+  --react-shadow: theme('colors.reactShadow', '#61dafbaa');
+  --muted: theme('colors.muted', '#888');
 }
 
 body {

--- a/cueit-admin/tailwind.config.js
+++ b/cueit-admin/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
         secondary: theme.colors.secondary,
         accent: theme.colors.accent,
         surface: theme.colors.surface,
+        content: theme.colors.content,
         logoShadow: theme.colors.logoShadow,
         reactShadow: theme.colors.reactShadow,
         muted: theme.colors.muted,


### PR DESCRIPTION
## Summary
- expose `content` color so theme tokens resolve
- specify fallback values for custom CSS variables

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Cannot apply unknown utility class `bg-white`)*

------
https://chatgpt.com/codex/tasks/task_e_6868d2dc8fdc8333a02b4e1f1a294105