### PR TITLE
Fix admin build errors for macOS packaging

### DIFF
--- a/cueit-admin/src/App.jsx
+++ b/cueit-admin/src/App.jsx
@@ -204,7 +204,7 @@ function App() {
           ) : logs.length === 0 ? (
             <p className="text-gray-400 text-center">No tickets found.</p>
           ) : (
-            <div className="panel overflow-hidden">
+            <div className="bg-white text-gray-900 rounded-lg shadow p-6 transition-all overflow-hidden">
               <div className="mb-12 px-4 space-y-4">
                 <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div className="flex gap-3 justify-end w-full flex-wrap sm:flex-nowrap mb-4">

--- a/cueit-admin/src/index.css
+++ b/cueit-admin/src/index.css
@@ -23,6 +23,3 @@ body {
   min-height: 100vh;
 }
 
-.panel {
-  @apply bg-white text-gray-900 rounded-lg shadow p-6 transition-all;
-}

--- a/cueit-admin/src/main.jsx
+++ b/cueit-admin/src/main.jsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { ToastProvider } from './Toast.jsx'
+import ToastProvider from './Toast.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/cueit-admin/tailwind.config.js
+++ b/cueit-admin/tailwind.config.js
@@ -1,4 +1,5 @@
 import daisyui from 'daisyui';
+import colors from 'tailwindcss/colors';
 import theme from '../design/theme.js';
 
 export default {
@@ -10,6 +11,7 @@ export default {
       },
       spacing: theme.spacing,
       colors: {
+        ...colors,
         primary: theme.colors.primary,
         secondary: theme.colors.secondary,
         accent: theme.colors.accent,
@@ -18,6 +20,7 @@ export default {
         logoShadow: theme.colors.logoShadow,
         reactShadow: theme.colors.reactShadow,
         muted: theme.colors.muted,
+        base: theme.colors.base,
       },
     },
   },


### PR DESCRIPTION
## Summary
- update Tailwind config to include default colors
- drop custom `.panel` utility in admin UI
- fix ToastProvider import in React entrypoint
- replace `.panel` usage in App component

## Testing
- `npm run build` in `cueit-admin`
- `npm run lint` in `cueit-admin`
- `npm test` in `cueit-admin`
- `npm install` in `cueit-macos`
- `npm test` in `cueit-macos`


------
https://chatgpt.com/codex/tasks/task_e_6868d4b4471083339aedd08b8e172f7a