### PR TITLE
Remove leftover pkg in installer

### DIFF
--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -32,5 +32,6 @@ fi
 pkgbuild --root "$APP_PATH" --install-location /Applications \
   --identifier com.cueit.launcher --version "$VERSION" "$APP_DIR/CueIT.pkg"
 productbuild --package "$APP_DIR/CueIT.pkg" "$APP_DIR/CueIT-$VERSION.pkg"
+rm "$APP_DIR/CueIT.pkg"
 
 echo "Installer created at $APP_DIR/CueIT-$VERSION.pkg"


### PR DESCRIPTION
## Summary
- delete temporary CueIT.pkg after productbuild

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ef4806f08333bc7511936afc222c