### PR TITLE
Update docs and installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ dependencies if the `node_modules` directory is missing.
 
 ### macOS Launcher
 
-Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./installers/make-installer.sh` to build a `.pkg` installer, install it and launch **CueIT** from Applications.
+Use the Electron launcher in `cueit-macos` to start the services with a single click. Run `./installers/make-installer.sh <version> [arch]` to build a `.pkg` installer and launch **CueIT** from Applications. Pass `arm64`, `x64` or `universal` as the optional architecture.
 All installer scripts reside in the `installers/` directory.
 See [docs/installers.md](docs/installers.md) for detailed instructions.
 Run `./installers/uninstall-macos.sh` to remove the app and `./installers/upgrade-macos.sh` to rebuild and reinstall.

--- a/cueit-macos/README.md
+++ b/cueit-macos/README.md
@@ -4,7 +4,7 @@ Electron launcher packaged for macOS.
 
 ## Building
 
-Run `../installers/make-installer.sh <version>` on an Apple Silicon Mac to generate an **arm64** installer. Pass `universal` after the version to create a combined package for Intel and Apple Silicon Macs. Install the package to `/Applications`. The minimum supported macOS version is **12**.
+Run `../installers/make-installer.sh <version> [arch]` on macOS to build the installer. The optional `arch` value may be `arm64`, `x64` or `universal` (default). Install the resulting package to `/Applications`. The minimum supported macOS version is **12**.
 All installer scripts live in the repository's `installers/` directory. Use `../installers/uninstall-macos.sh` to remove the application. The helper script `../installers/upgrade-macos.sh` rebuilds a new package and reinstalls it.
 
 ## Setup

--- a/docs/installers.md
+++ b/docs/installers.md
@@ -4,7 +4,7 @@ All installation utilities are kept in the `installers/` directory. They package
 
 ## macOS
 
-1. `./installers/make-installer.sh <version>` builds `CueIT-<version>.pkg` and installs it.
+1. `./installers/make-installer.sh <version> [arch]` builds `CueIT-<version>.pkg` for the specified architecture (`arm64`, `x64` or `universal`).
 2. `./installers/uninstall-macos.sh` removes the application from `/Applications`.
 3. `./installers/upgrade-macos.sh <version>` rebuilds the package (or accepts a `.pkg` path) and reinstalls it.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,8 @@ Use the installer script for your operating system:
 - **Windows** – run `./installers/make-windows-installer.ps1 -Version <version>` to build `CueIT-<version>.exe` and execute it.
 - **Linux** – run `./installers/make-linux-installer.sh <version>` to build an AppImage and launch it.
 
+After installation you can launch **CueIT** from `/Applications` on macOS, from the Start Menu on Windows and by running the AppImage on Linux. See the [macOS launcher](../README.md#macos-launcher) section for details.
+
 All installer scripts are located under the `installers/` directory. On macOS you can remove the application with `./installers/uninstall-macos.sh` and upgrade it with `./installers/upgrade-macos.sh`. See [installers.md](installers.md) for more options.
 These scripts package the Electron launcher along with the API and web apps.
 

--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -5,8 +5,14 @@ cd "$SCRIPT_DIR/.."
 
 APP_DIR="cueit-macos"
 VERSION="${1:-1.0.0}"
-
-arch="universal"
+arch="${2:-universal}"
+case "$arch" in
+  arm64|x64|universal) ;;
+  *)
+    echo "Usage: $0 <version> [arm64|x64|universal]"
+    exit 1
+    ;;
+esac
 
 npm --prefix "$APP_DIR" install
 npm --prefix cueit-admin install


### PR DESCRIPTION
## Summary
- clarify where to find CueIT after running installers
- allow architecture parameter for macOS installer script
- document new `make-installer.sh` usage in README files

## Testing
- `npm test` *(fails: token missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868ee6483248333a06106848b705663