### PR TITLE
Add unified env example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,44 @@
+# cueit-api
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+SMTP_SECURE=false
+HELPDESK_EMAIL=helpdesk@yourcompany.com
+API_PORT=3000
+TLS_CERT_PATH=
+TLS_KEY_PATH=
+LOGO_URL=/logo.png
+SESSION_SECRET=change_this
+CORS_ORIGINS=https://localhost:5173
+SAML_ENTRY_POINT=https://idp.example.com/sso
+SAML_ISSUER=https://cueit.example.com
+SAML_CERT=-----BEGIN CERTIFICATE-----\n...
+SAML_CALLBACK_URL=https://localhost:3000/login/callback
+ADMIN_URL=https://localhost:5173
+HELPSCOUT_API_KEY=
+HELPSCOUT_MAILBOX_ID=
+HELPSCOUT_SMTP_FALLBACK=false
+JWT_SECRET=change_this_too
+JWT_EXPIRES_IN=1h
+SLACK_WEBHOOK_URL=
+SERVICENOW_INSTANCE=
+SERVICENOW_USER=
+SERVICENOW_PASS=
+
+# cueit-admin
+VITE_API_URL=https://localhost:3000
+VITE_LOGO_URL=/logo.png
+VITE_ACTIVATE_URL=https://localhost:5174
+
+# cueit-activate
+VITE_API_URL=https://localhost:3000
+VITE_ADMIN_URL=https://localhost:5173
+
+# cueit-slack
+SLACK_SIGNING_SECRET=your-secret
+SLACK_BOT_TOKEN=xoxb-your-token
+API_URL=https://localhost:3000
+SLACK_PORT=3001
+JWT_SECRET=change_this_too
+VITE_ADMIN_URL=https://localhost:5173

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ page and SwiftUI kiosk app.
 ## Setup
 
 Run `./installers/setup.sh` to install Node.js, SQLite and all project dependencies in one step.
+Copy `.env.local.example` to `.env.local` and adjust any values for your machine.
 Next run `./scripts/init-env.sh` to create the `.env` files for each app (edit them before launching).
 You can also follow the manual instructions below.
 See [Local vs Production Setup](docs/environments.md) for details on configuring the environment variables used by each service.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,6 +1,6 @@
 # Local vs Production Setup
 
-This project ships with sample environment files for each app. Copy these files to `.env` and adjust the values for your environment.
+This project ships with sample environment files for each app. A unified example is provided at `.env.local.example` in the repository root. Copy that file to `.env.local` for reference, then copy each example file to `.env` and adjust the values for your environment.
 
 ## Local Development
 
@@ -52,4 +52,4 @@ When deploying to a live environment you must update each `.env` file with real 
   `sameSite=lax` and `secure` enabled.
 - Do not set `DISABLE_AUTH=true` when `NODE_ENV` is `production`.
 
-Copy the respective `.env.example` file to `.env` in each folder, then edit the settings above before starting the services.
+Copy the respective `.env.example` file to `.env` in each folder (or start from the combined `.env.local.example`), then edit the settings above before starting the services.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ These scripts package the Electron launcher along with the API and web apps.
 
 ## 2. Configure
 
-After installing or cloning the repository, copy each `.env.example` file to `.env` and edit the values for your environment. See [Local vs Production Setup](environments.md) for details on every variable.
+After installing or cloning the repository, copy `.env.local.example` to `.env.local` and run `./scripts/init-env.sh` to generate the `.env` files for each service. Edit them as needed. See [Local vs Production Setup](environments.md) for details on every variable.
 Set `SLACK_WEBHOOK_URL` in `cueit-api/.env` if you want notification events posted to Slack.
 
 ## 3. Launch Services

--- a/installers/setup.sh
+++ b/installers/setup.sh
@@ -43,5 +43,14 @@ if [ -d cueit-slack ]; then
   popd >/dev/null
 fi
 
-echo "Run ./scripts/init-env.sh to create .env files, then edit them before starting the services."
-echo "Setup complete."
+# Automatically create .env files if they do not exist
+missing_env=false
+for dir in cueit-api cueit-admin cueit-activate cueit-slack; do
+  [ -f "$dir/.env" ] || missing_env=true
+done
+if [ "$missing_env" = true ]; then
+  echo "Initializing .env files..."
+  ./scripts/init-env.sh
+fi
+
+echo "Setup complete. Edit the .env files before starting the services."


### PR DESCRIPTION
## Summary
- add consolidated `.env.local.example`
- mention new file in README setup instructions
- refer to the unified env file in quickstart and environments docs
- auto-create `.env` files in `installers/setup.sh`

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686963f32d3c8333839af923d5281918