### PR TITLE
Add production installs to macOS installer script

### DIFF
--- a/installers/make-installer.sh
+++ b/installers/make-installer.sh
@@ -17,6 +17,11 @@ esac
 npm --prefix "$APP_DIR" install
 npm --prefix cueit-admin install
 npm --prefix cueit-admin run build
+# Install production dependencies so the packaged app works
+# without running npm install after copying to /Applications
+npm --prefix cueit-api ci --production
+npm --prefix cueit-activate ci --production
+npm --prefix cueit-slack ci --production
 npx --prefix "$APP_DIR" electron-packager "$APP_DIR" CueIT \
   --platform=darwin --arch="$arch" --out "$APP_DIR/dist" --overwrite
 


### PR DESCRIPTION
## Summary
- ensure macOS installer installs backend production dependencies

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68696457ee748333877fd2b391cf38e9