### PR TITLE
Add macOS installer test

### DIFF
--- a/cueit-macos/package.json
+++ b/cueit-macos/package.json
@@ -6,7 +6,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js test"
   },
   "dependencies": {
     "electron": "^30.0.0"

--- a/cueit-macos/test/make-installer.test.js
+++ b/cueit-macos/test/make-installer.test.js
@@ -1,0 +1,61 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(execFile);
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const repoRoot = path.resolve(__dirname, '..', '..');
+const script = path.join(repoRoot, 'installers', 'make-installer.sh');
+
+async function setupRepo(tmp) {
+  const dirs = ['cueit-macos', 'cueit-admin', 'cueit-api', 'cueit-activate', 'cueit-slack', 'design', 'installers'];
+  for (const d of dirs) {
+    await fs.mkdir(path.join(tmp, d), { recursive: true });
+  }
+  for (const p of ['cueit-api', 'cueit-admin', 'cueit-activate', 'cueit-slack']) {
+    await fs.writeFile(path.join(tmp, p, '.env.example'), '');
+  }
+  await fs.writeFile(path.join(tmp, 'installers', 'start-all.sh'), '');
+  await fs.mkdir(path.join(tmp, 'cueit-macos', 'dist', 'CueIT-darwin-universal', 'CueIT.app'), { recursive: true });
+  await fs.copyFile(script, path.join(tmp, 'installers', 'make-installer.sh'));
+}
+
+async function setupBin(tmp) {
+  const bin = path.join(tmp, 'bin');
+  await fs.mkdir(bin);
+  const scripts = {
+    npm: '#!/usr/bin/env bash\nexit 0',
+    npx: '#!/usr/bin/env bash\nexit 0',
+    pkgbuild: '#!/usr/bin/env bash\nout="${@: -1}"\ntouch "$out"',
+    productbuild: '#!/usr/bin/env bash\nout="${@: -1}"\ntouch "$out"'
+  };
+  for (const [name, content] of Object.entries(scripts)) {
+    const p = path.join(bin, name);
+    await fs.writeFile(p, content);
+    await fs.chmod(p, 0o755);
+  }
+  return bin;
+}
+
+describe('make-installer.sh', () => {
+  let tmp;
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'cueit-'));
+    await setupRepo(tmp);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test('creates pkg file', async () => {
+    const bin = await setupBin(tmp);
+    const version = '1.2.3';
+    const env = { PATH: `${bin}:${process.env.PATH}` };
+    await exec(path.join(tmp, 'installers', 'make-installer.sh'), [version], { cwd: tmp, env });
+    const pkgPath = path.join(tmp, 'cueit-macos', `CueIT-${version}.pkg`);
+    await fs.access(pkgPath);
+  });
+});


### PR DESCRIPTION
## Summary
- verify that make-installer.sh builds a pkg
- reference new test from npm script

## Testing
- `npm test` inside `cueit-macos`

------
https://chatgpt.com/codex/tasks/task_e_6869645cf6788333bcc320431ef78b70