### PR TITLE
Update start commands for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Scripts are provided to launch the API, admin UI, activation page and Slack
 service together using `concurrently`. When running the script you will be
 prompted to choose which apps to start (press **Enter** for all). For each
 selected app the script verifies that a `.env` file exists and installs
-dependencies if the `node_modules` directory is missing.
+dependencies if the `node_modules` directory is missing. Each service is
+started with `npm start` so its environment file loads correctly.
 
 #### macOS / Linux
 

--- a/cueit-api/package.json
+++ b/cueit-api/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",

--- a/cueit-slack/package.json
+++ b/cueit-slack/package.json
@@ -11,7 +11,8 @@
     "jsonwebtoken": "^9.0.2"
   },
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "start": "node index.js"
   },
   "devDependencies": {
     "jest": "^29.6.1"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,4 +28,7 @@ You can start all services from the command line:
 ./installers/start-all.sh
 ```
 
+Each service launches via `npm start`, ensuring its `.env` file is loaded
+correctly.
+
 On Windows use `start-all.ps1` instead. The packaged Electron app created above also runs the same script in the background so you can start everything with a single click.

--- a/installers/start-all.ps1
+++ b/installers/start-all.ps1
@@ -1,9 +1,9 @@
 Set-Location (Join-Path $PSScriptRoot "..")
 $apps = @{
-  api      = @{ dir = 'cueit-api';      cmd = 'node cueit-api/index.js' }
+  api      = @{ dir = 'cueit-api';      cmd = 'npm --prefix cueit-api start' }
   admin    = @{ dir = 'cueit-admin';    cmd = 'npm --prefix cueit-admin run dev' }
   activate = @{ dir = 'cueit-activate'; cmd = 'npm --prefix cueit-activate run dev' }
-  slack    = @{ dir = 'cueit-slack';    cmd = 'node cueit-slack/index.js' }
+  slack    = @{ dir = 'cueit-slack';    cmd = 'npm --prefix cueit-slack start' }
 }
 
 $input = Read-Host "Apps to start (api,admin,activate,slack or all) [all]"

--- a/installers/start-all.sh
+++ b/installers/start-all.sh
@@ -15,10 +15,10 @@ get_dir() {
 
 get_cmd() {
   case "$1" in
-    api) echo "node cueit-api/index.js" ;;
+    api) echo "npm --prefix cueit-api start" ;;
     admin) echo "npm --prefix cueit-admin run dev" ;;
     activate) echo "npm --prefix cueit-activate run dev" ;;
-    slack) echo "node cueit-slack/index.js" ;;
+    slack) echo "npm --prefix cueit-slack start" ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary
- add npm start script to cueit-api and cueit-slack
- launch API and Slack service via npm in start-all scripts
- document that start-all scripts now load `.env` correctly

## Testing
- `npm --prefix cueit-admin run lint`
- `npm --prefix cueit-api test` *(fails: SQLITE_ERROR)*
- `npm --prefix cueit-slack test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b42c3fd48333bc59fa7b5595ea3e