### PR TITLE
Add FAVICON_URL placeholders

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,6 +9,7 @@ API_PORT=3000
 TLS_CERT_PATH=
 TLS_KEY_PATH=
 LOGO_URL=/logo.png
+FAVICON_URL=/vite.svg
 SESSION_SECRET=change_this
 CORS_ORIGINS=https://localhost:5173
 SAML_ENTRY_POINT=https://idp.example.com/sso
@@ -31,6 +32,7 @@ SERVICENOW_PASS=
 # cueit-admin
 VITE_API_URL=https://localhost:3000
 VITE_LOGO_URL=/logo.png
+VITE_FAVICON_URL=/vite.svg
 VITE_ACTIVATE_URL=https://localhost:5174
 
 # cueit-activate

--- a/cueit-admin/.env.example
+++ b/cueit-admin/.env.example
@@ -1,3 +1,4 @@
 VITE_API_URL=https://localhost:3000
 VITE_LOGO_URL=/logo.png
+VITE_FAVICON_URL=/vite.svg
 VITE_ACTIVATE_URL=https://localhost:5174

--- a/cueit-api/.env.example
+++ b/cueit-api/.env.example
@@ -8,6 +8,7 @@ API_PORT=3000
 TLS_CERT_PATH=
 TLS_KEY_PATH=
 LOGO_URL=/logo.png
+FAVICON_URL=/vite.svg
 SESSION_SECRET=change_this
 CORS_ORIGINS=https://localhost:5173
 SAML_ENTRY_POINT=https://idp.example.com/sso


### PR DESCRIPTION
## Summary
- update example env files with `FAVICON_URL` variables

## Testing
- `npm test` (fails: cueit-api)
- `npm test` in cueit-admin
- `npm run lint` in cueit-admin
- `npm test` in cueit-activate
- `npm ci && npm test` in cueit-macos
- `npm test` in cueit-slack
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b70339c08333a55d676fa44fe122