### PR TITLE
Add RBAC and directory search

### DIFF
--- a/cueit-api/test/00_setup.js
+++ b/cueit-api/test/00_setup.js
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import axios from 'axios';
+import db from '../db.js';
 
 if (!process.env.DISABLE_AUTH) {
   process.env.DISABLE_AUTH = 'true';
@@ -26,6 +27,20 @@ axios.post = (...args) => axiosBehavior(...args);
 const mod = await import('../index.js');
 app = mod.default;
 globalThis.app = app;
+
+await new Promise((resolve) => {
+  function check() {
+    db.get(
+      'SELECT id FROM users WHERE email=?',
+      ['admin@example.com'],
+      (err, row) => {
+        if (row) return resolve();
+        setTimeout(check, 10);
+      }
+    );
+  }
+  check();
+});
 
 globalThis.setSendBehavior = (fn) => {
   sendBehavior = fn;

--- a/cueit-api/test/directory.test.js
+++ b/cueit-api/test/directory.test.js
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import assert from 'assert';
+import db from '../db.js';
+const app = globalThis.app;
+
+beforeEach((done) => {
+  db.serialize(() => {
+    db.run('DELETE FROM directory_integrations');
+    db.run(
+      "INSERT INTO directory_integrations (id, provider, settings) VALUES (1,'mock','[{\"name\":\"Alice\",\"email\":\"alice@example.com\"},{\"name\":\"Bob\",\"email\":\"bob@example.com\"}]')",
+      done
+    );
+  });
+});
+
+describe('Directory search', function() {
+  it('returns matches', async function() {
+    const res = await request(app)
+      .get('/api/directory-search')
+      .query({ q: 'ali' })
+      .expect(200);
+    assert.strictEqual(res.body.length, 1);
+    assert.strictEqual(res.body[0].email, 'alice@example.com');
+  });
+});

--- a/cueit-api/test/rbac.test.js
+++ b/cueit-api/test/rbac.test.js
@@ -1,0 +1,88 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import assert from 'assert';
+import sqlite3pkg from 'sqlite3';
+import bcrypt from 'bcryptjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiPath = path.join(__dirname, '..', 'index.js');
+const port = 3051;
+let proc;
+const nodeBin = process.execPath;
+const sqlite3 = sqlite3pkg.verbose();
+const dbFile = path.join(__dirname, '..', 'log.sqlite');
+
+function createUser(email, name, password) {
+  return new Promise((resolve) => {
+    const db = new sqlite3.Database(dbFile);
+    const hash = bcrypt.hashSync(password, 10);
+    db.run(
+      `INSERT INTO users (name, email, passwordHash) VALUES (?, ?, ?)`,
+      [name, email, hash],
+      () => {
+        db.close();
+        resolve();
+      }
+    );
+  });
+}
+
+function startServer(done) {
+  createUser('bob@example.com', 'Bob', 'bob').then(() => {
+    proc = spawn(nodeBin, [apiPath], {
+      cwd: path.join(__dirname, '..'),
+      env: {
+        ...process.env,
+        API_PORT: String(port),
+        NODE_ENV: 'development',
+        DISABLE_AUTH: 'false',
+        SESSION_SECRET: 'test',
+        SAML_ENTRY_POINT: 'http://localhost/saml',
+        SAML_ISSUER: 'cueit',
+        SAML_CALLBACK_URL: 'http://localhost/callback',
+        SAML_CERT: 'dummy',
+        JWT_SECRET: 'rbactest',
+      },
+    });
+    proc.stdout.on('data', (d) => {
+      if (d.toString().includes('CueIT API running')) done();
+    });
+  });
+}
+
+function stopServer() {
+  if (proc) proc.kill();
+}
+
+describe('RBAC permissions', function () {
+  this.timeout(5000);
+  before((done) => startServer(done));
+  after(stopServer);
+
+  it('denies access without permission', async () => {
+    const res = await fetch(`http://localhost:${port}/api/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'bob@example.com', password: 'bob' }),
+    });
+    const data = await res.json();
+    const res2 = await fetch(`http://localhost:${port}/api/users`, {
+      headers: { Authorization: `Bearer ${data.token}` },
+    });
+    assert.strictEqual(res2.status, 403);
+  });
+
+  it('allows admin user', async () => {
+    const res = await fetch(`http://localhost:${port}/api/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'admin@example.com', password: 'admin' }),
+    });
+    const data = await res.json();
+    const res2 = await fetch(`http://localhost:${port}/api/users`, {
+      headers: { Authorization: `Bearer ${data.token}` },
+    });
+    assert.strictEqual(res2.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- implement RBAC middleware and directory search API
- create role/permission tables in DB
- seed admin role and permissions
- manage user roles and permissions via new endpoints
- add tests for directory search and RBAC
- wait for database seed before running tests

## Testing
- `./installers/setup.sh`
- `npx -y node@18 node_modules/mocha/bin/mocha` *(fails: row missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ab53c7df083338f5ca5e8e431f8e8