### PR TITLE
Add directory integration and kiosk search

### DIFF
--- a/cueit-admin/src/DirectoryPanel.jsx
+++ b/cueit-admin/src/DirectoryPanel.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import useToast from './useToast.js';
+import useApiError from './useApiError.js';
+
+export default function DirectoryPanel() {
+  const [cfg, setCfg] = useState({
+    directoryProvider: 'mock',
+    directoryUrl: '',
+    directoryToken: '',
+  });
+  const api = import.meta.env.VITE_API_URL;
+  const toast = useToast();
+  const handleApiError = useApiError();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await axios.get(`${api}/api/directory-config`);
+        setCfg(res.data);
+      } catch (err) {
+        handleApiError(err, 'Failed to load directory config');
+      }
+    })();
+  }, [api, handleApiError]);
+
+  const save = async () => {
+    try {
+      await axios.put(`${api}/api/directory-config`, cfg);
+      toast('Saved');
+    } catch (err) {
+      handleApiError(err, 'Failed to save config');
+    }
+  };
+
+  const test = async () => {
+    try {
+      await axios.get(`${api}/api/directory-search`, { params: { q: 'test' } });
+      toast('Connection successful');
+    } catch (err) {
+      handleApiError(err, 'Connection failed');
+    }
+  };
+
+  return (
+    <div className="space-y-3 text-sm">
+      <label className="block">
+        Provider
+        <select
+          value={cfg.directoryProvider}
+          onChange={(e) => setCfg({ ...cfg, directoryProvider: e.target.value })}
+          className="mt-1 w-full px-2 py-1 rounded text-black"
+        >
+          <option value="mock">Mock</option>
+          <option value="scim">SCIM</option>
+        </select>
+      </label>
+      <label className="block">
+        URL
+        <input
+          type="text"
+          value={cfg.directoryUrl || ''}
+          onChange={(e) => setCfg({ ...cfg, directoryUrl: e.target.value })}
+          className="mt-1 w-full px-2 py-1 rounded text-black"
+        />
+      </label>
+      <label className="block">
+        Token
+        <input
+          type="text"
+          value={cfg.directoryToken || ''}
+          onChange={(e) => setCfg({ ...cfg, directoryToken: e.target.value })}
+          className="mt-1 w-full px-2 py-1 rounded text-black"
+        />
+      </label>
+      <div className="space-x-2">
+        <button onClick={save} className="px-4 py-1 bg-blue-600 text-white rounded">
+          Save
+        </button>
+        <button onClick={test} className="px-4 py-1 bg-green-600 text-white rounded">
+          Test
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/cueit-admin/src/SettingsPanel.jsx
+++ b/cueit-admin/src/SettingsPanel.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import UsersPanel from './UsersPanel.jsx';
 import FeedbackPanel from './FeedbackPanel.jsx';
 import NotificationsPanel from './NotificationsPanel.jsx';
+import DirectoryPanel from './DirectoryPanel.jsx';
 import useToast from './useToast.js';
 import useApiError from './useApiError.js';
 import { colors } from './theme.js';
@@ -123,6 +124,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
           <button className={`mr-4 pb-2 ${tab === 'users' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('users')}>Users</button>
           <button className={`mr-4 pb-2 ${tab === 'notifications' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('notifications')}>Notifications</button>
           <button className={`mr-4 pb-2 ${tab === 'status' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('status')}>Status</button>
+          <button className={`mr-4 pb-2 ${tab === 'directory' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('directory')}>Directory</button>
           <button className={`pb-2 ${tab === 'feedback' ? 'border-b-2 border-white' : 'text-gray-400'}`} onClick={() => setTab('feedback')}>Feedback</button>
         </div>
         {tab === 'general' && (
@@ -373,6 +375,7 @@ export default function SettingsPanel({ open, onClose, config, setConfig }) {
             ))}
           </div>
         )}
+        {tab === 'directory' && <DirectoryPanel />}
         {tab === 'feedback' && <FeedbackPanel open={open && tab === 'feedback'} />}
       </div>
     </div>

--- a/cueit-admin/src/__tests__/DirectoryPanel.test.jsx
+++ b/cueit-admin/src/__tests__/DirectoryPanel.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import DirectoryPanel from '../DirectoryPanel.jsx';
+
+jest.mock('axios');
+
+test('saves and tests directory config', async () => {
+  axios.get.mockResolvedValueOnce({ data: { directoryProvider: 'mock', directoryUrl: '', directoryToken: '' } });
+  axios.put.mockResolvedValue({});
+  axios.get.mockResolvedValue({ data: [] });
+  render(<DirectoryPanel />);
+  await screen.findByText('Provider');
+  const urlInput = screen.getByLabelText('URL');
+  await userEvent.type(urlInput, 'http://x');
+  await userEvent.click(screen.getByText('Save'));
+  expect(axios.put).toHaveBeenCalledWith(expect.stringContaining('/api/directory-config'), expect.objectContaining({ directoryUrl: 'http://x' }));
+  await userEvent.click(screen.getByText('Test'));
+  expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/api/directory-search'), { params: { q: 'test' } });
+});

--- a/cueit-admin/src/__tests__/SettingsPanel.test.jsx
+++ b/cueit-admin/src/__tests__/SettingsPanel.test.jsx
@@ -27,4 +27,11 @@ describe('SettingsPanel', () => {
     await userEvent.click(toggleBtn);
     expect(axios.put).toHaveBeenCalledWith(expect.stringContaining('/api/kiosks/k1/active'), { active: true });
   });
+
+  test('opens directory panel', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+    render(<SettingsPanel open={true} onClose={() => {}} config={{}} setConfig={() => {}} />);
+    await userEvent.click(screen.getByText('Directory'));
+    expect(await screen.findByText('Provider')).toBeInTheDocument();
+  });
 });

--- a/cueit-api/README.md
+++ b/cueit-api/README.md
@@ -53,6 +53,8 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
 - Old logs older than 30 days are purged automatically (set `LOG_RETENTION_DAYS` to adjust).
 - `GET /api/config` – return configuration key/value pairs.
 - `PUT /api/config` – insert or update configuration values.
+- `GET /api/directory-config` – retrieve directory integration settings.
+- `PUT /api/directory-config` – update directory integration settings.
 
 ### Kiosk Management
 
@@ -61,6 +63,10 @@ settings from `.env` and listens on `API_PORT` (default `3000`).
 - `PUT /api/kiosks/:id` – update kiosk branding and active state.
 - `GET /api/kiosks` – list all kiosks.
 - `PUT /api/kiosks/:id/active` – toggle its active flag.
+- `GET /api/kiosks/:id/status` – fetch status settings for a kiosk.
+- `PUT /api/kiosks/:id/status` – update status settings.
+- `GET /api/kiosks/:id/users` – search the configured directory.
+- `POST /api/kiosks/:id/users` – create a user when lookup fails.
 - `DELETE /api/kiosks/:id` – delete a kiosk by id.
 - `DELETE /api/kiosks` – remove all kiosks.
 

--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -159,7 +159,11 @@ db.serialize(() => {
     statusClosedMsg: 'Closed',
     statusErrorMsg: 'Error',
     adminPassword: bcrypt.hashSync(process.env.ADMIN_PASSWORD || 'admin', 10),
-    scimToken: process.env.SCIM_TOKEN || ''
+    scimToken: process.env.SCIM_TOKEN || '',
+    directoryEnabled: '0',
+    directoryProvider: 'mock',
+    directoryUrl: '',
+    directoryToken: ''
   };
   const stmt = db.prepare(`INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)`);
   for (const [key, value] of Object.entries(defaults)) {

--- a/cueit-api/directory.js
+++ b/cueit-api/directory.js
@@ -1,0 +1,66 @@
+import db from './db.js';
+import axios from 'axios';
+
+export async function getConfig() {
+  return new Promise((resolve, reject) => {
+    db.all(
+      "SELECT key, value FROM config WHERE key LIKE 'directory%'",
+      (err, rows) => {
+        if (err) return reject(err);
+        const cfg = Object.fromEntries(rows.map((r) => [r.key, r.value]));
+        resolve(cfg);
+      }
+    );
+  });
+}
+
+export async function searchDirectory(q) {
+  const cfg = await getConfig();
+  if (cfg.directoryEnabled !== '1') return [];
+  const provider = cfg.directoryProvider || 'mock';
+  if (provider === 'scim') {
+    const url = (cfg.directoryUrl || '').replace(/\/$/, '');
+    const token = cfg.directoryToken || '';
+    const resp = await axios.get(`${url}/Users`, {
+      params: { filter: `userName co \"${q}\"` },
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const list = resp.data?.Resources || [];
+    return list.map((u) => ({ name: u.displayName, email: u.userName }));
+  }
+  return new Promise((resolve, reject) => {
+    db.get(
+      'SELECT settings FROM directory_integrations WHERE provider=?',
+      [provider],
+      (err, row) => {
+        if (err) return reject(err);
+        if (!row) return resolve([]);
+        let arr = [];
+        try {
+          arr = JSON.parse(row.settings || '[]');
+        } catch {}
+        const ql = q.toLowerCase();
+        resolve(
+          arr.filter(
+            (u) =>
+              u.name.toLowerCase().includes(ql) ||
+              (u.email && u.email.toLowerCase().includes(ql))
+          )
+        );
+      }
+    );
+  });
+}
+
+export async function createUser(name, email) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'INSERT INTO users (name, email) VALUES (?, ?)',
+      [name, email],
+      function (err) {
+        if (err) return reject(err);
+        resolve(this.lastID);
+      }
+    );
+  });
+}

--- a/cueit-api/test/directory.test.js
+++ b/cueit-api/test/directory.test.js
@@ -2,24 +2,66 @@ import request from 'supertest';
 import assert from 'assert';
 import db from '../db.js';
 const app = globalThis.app;
+const token = 'kiosktoken';
 
-beforeEach((done) => {
+function seedDir(done) {
   db.serialize(() => {
     db.run('DELETE FROM directory_integrations');
     db.run(
-      "INSERT INTO directory_integrations (id, provider, settings) VALUES (1,'mock','[{\"name\":\"Alice\",\"email\":\"alice@example.com\"},{\"name\":\"Bob\",\"email\":\"bob@example.com\"}]')",
-      done
+      "INSERT INTO directory_integrations (id, provider, settings) VALUES (1,'mock','[{\"name\":\"Alice\",\"email\":\"alice@example.com\"}]')"
     );
+    db.run("DELETE FROM config WHERE key LIKE 'directory%'");
+    const stmt = db.prepare('INSERT INTO config (key, value) VALUES (?, ?)');
+    stmt.run('directoryEnabled', '1');
+    stmt.run('directoryProvider', 'mock');
+    stmt.run('directoryUrl', '');
+    stmt.run('directoryToken', '');
+    stmt.finalize(done);
   });
+}
+
+beforeEach((done) => {
+  db.run('DELETE FROM users', () => seedDir(done));
 });
 
-describe('Directory search', function() {
-  it('returns matches', async function() {
+describe('Directory search via kiosk', function () {
+  it('returns matches', async function () {
+    await request(app)
+      .post('/api/register-kiosk')
+      .send({ id: 'k1', token })
+      .expect(200);
+
     const res = await request(app)
-      .get('/api/directory-search')
+      .get('/api/kiosks/k1/users')
       .query({ q: 'ali' })
       .expect(200);
     assert.strictEqual(res.body.length, 1);
     assert.strictEqual(res.body[0].email, 'alice@example.com');
+  });
+
+  it('creates user when not found', async function () {
+    const res = await request(app)
+      .post('/api/kiosks/k1/users')
+      .send({ name: 'New', email: 'n@e.com' })
+      .expect(200);
+    assert(res.body.id, 'id missing');
+    const row = await new Promise((resolve) => {
+      db.get('SELECT * FROM users WHERE id=?', [res.body.id], (e, r) => resolve(r));
+    });
+    assert(row, 'row missing');
+  });
+
+  it('returns error when provider fails', async function () {
+    setAxiosBehavior(() => {
+      throw new Error('fail');
+    });
+    await db.run("UPDATE config SET value='scim' WHERE key='directoryProvider'");
+    await request(app)
+      .post('/api/register-kiosk')
+      .send({ id: 'k2', token })
+      .expect(200);
+    await request(app)
+      .get('/api/kiosks/k2/users?q=x')
+      .expect(500);
   });
 });


### PR DESCRIPTION
## Summary
- support directory integration in config
- expose new directory config endpoints and kiosk user search routes
- implement directory query helper
- add admin UI panel for directory settings
- document new API endpoints

## Testing
- `npm run lint` in `cueit-admin`
- `npm test` in `cueit-admin`
- `npx mocha` *(fails: node-sqlite3 crashed)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7d1304483339d4398c4b2f213fe