### PR TITLE
Add role-based auth and admin role management

### DIFF
--- a/cueit-api/db.js
+++ b/cueit-api/db.js
@@ -142,11 +142,19 @@ db.serialize(() => {
   addColumnIfMissing('logs', 'servicenow_id TEXT');
 
   // seed role/permission tables
-  db.run("INSERT OR IGNORE INTO roles (id, name) VALUES (1, 'admin')");
+  db.run("INSERT OR IGNORE INTO roles (id, name) VALUES (1, 'Super Admin')");
+  db.run("INSERT OR IGNORE INTO roles (id, name) VALUES (2, 'Admin')");
   db.run("INSERT OR IGNORE INTO permissions (id, name) VALUES (1, 'manage_users')");
   db.run("INSERT OR IGNORE INTO permissions (id, name) VALUES (2, 'manage_roles')");
-  db.run("INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (1, 1)");
-  db.run("INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (1, 2)");
+  db.run(
+    "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (1, 1)"
+  );
+  db.run(
+    "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (1, 2)"
+  );
+  db.run(
+    "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (2, 1)"
+  );
   db.run("INSERT OR IGNORE INTO directory_integrations (id, provider, settings) VALUES (1, 'mock', '[]')");
 
   // insert default config if not present


### PR DESCRIPTION
## Summary
- seed Super Admin and Admin roles
- add role-based middleware in API
- include user roles in `/api/users` and restrict endpoints by role
- extend directory search with unprivileged users
- show and edit roles in admin UI

## Testing
- `npm run lint` in cueit-admin
- `npm test` in cueit-admin
- `npm test` in cueit-activate
- `npm test` in cueit-slack
- `npm test` in cueit-api *(fails: Error::ThrowAsJavaScriptException)*

------
https://chatgpt.com/codex/tasks/task_e_686ab864c4dc83339d7d94bd3138f88f