### PR TITLE
Fix auth persistence in admin app

### DIFF
--- a/cueit-admin/src/App.tsx
+++ b/cueit-admin/src/App.tsx
@@ -29,7 +29,7 @@ const queryClient = new QueryClient({
 });
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { isAuthenticated, setUser } = useAuthStore();
+  const { isAuthenticated, login } = useAuthStore();
   const [loading, setLoading] = React.useState(true);
 
   useEffect(() => {
@@ -38,7 +38,7 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
       if (token) {
         try {
           const user = await api.me();
-          setUser(user);
+          login(token, user);
         } catch (error) {
           localStorage.removeItem('auth_token');
         }
@@ -47,7 +47,7 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
     };
 
     checkAuth();
-  }, [setUser]);
+  }, [login]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- ensure `checkAuth` in the admin app calls the zustand `login` method

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8306440083339a4dec59f63a4017