### PR TITLE
Update admin PIN verification

### DIFF
--- a/cueit-api/test/admin-pin.test.js
+++ b/cueit-api/test/admin-pin.test.js
@@ -1,0 +1,30 @@
+import request from 'supertest';
+import assert from 'assert';
+const app = globalThis.app;
+const token = 'kiosktoken';
+
+describe('Admin PIN verification', function() {
+  it('rejects request with missing token', function() {
+    return request(app)
+      .post('/api/verify-admin-pin')
+      .send({ pin: '123456' })
+      .expect(401);
+  });
+
+  it('accepts token in body', async function() {
+    const res = await request(app)
+      .post('/api/verify-admin-pin')
+      .send({ pin: '123456', token })
+      .expect(200);
+    assert.strictEqual(res.body.valid, true);
+  });
+
+  it('accepts token in Authorization header', async function() {
+    const res = await request(app)
+      .post('/api/verify-admin-pin')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ pin: '123456' })
+      .expect(200);
+    assert.strictEqual(res.body.valid, true);
+  });
+});


### PR DESCRIPTION
## Summary
- verify admin PIN endpoint accepts kiosk token
- test the new verification behavior

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx -y mocha "cueit-api/test/**/*.js"` *(fails: SQLITE_ERROR due to missing column)*

------
https://chatgpt.com/codex/tasks/task_e_686b830972a48333951c6f17d67e45ec