### PR TITLE
Fix test imports for Jest

### DIFF
--- a/test/database-setup.test.js
+++ b/test/database-setup.test.js
@@ -1,6 +1,6 @@
 // test/database-setup.test.js
 // Test file to validate the Nova Universe enhanced database setup
-import { novaDb } from '../src/lib/db/index.ts';
+import { novaDb } from '../src/lib/db/index.js';
 import { logger } from '../apps/api/logger.js';
 
 async function testDatabaseSetup() {

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -9,7 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Import from the created modules
-import { DatabaseFactory } from '../src/lib/db/index.ts';
+import { DatabaseFactory } from '../src/lib/db/index.js';
 import { logger } from '../apps/api/logger.js';
 
 // Test configuration


### PR DESCRIPTION
## Summary
- update database tests to import compiled JS modules instead of TypeScript files

## Testing
- `npx jest --config apps/api/jest.config.ts` *(fails: Validation Error `extensionsToTreatAsEsm`)*

------
https://chatgpt.com/codex/tasks/task_e_68878a7f8e0483339cde022bd2598515