### PR TITLE
Fix gql import

### DIFF
--- a/apps/api/graphql.js
+++ b/apps/api/graphql.js
@@ -1,6 +1,6 @@
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
-import { gql } from '@apollo/server';
+import gql from 'graphql-tag';
 import db from './db.js';
 import { verify } from './jwt.js';
 

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -31,6 +31,7 @@
         "figlet": "^1.8.2",
         "fs-extra": "^11.3.0",
         "graphql": "^16.11.0",
+        "graphql-tag": "^2.12.6",
         "helmet": "^8.1.0",
         "inquirer": "^12.8.2",
         "ioredis": "^5.4.1",
@@ -5664,6 +5665,21 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/has-flag": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
     "figlet": "^1.8.2",
     "fs-extra": "^11.3.0",
     "graphql": "^16.11.0",
+    "graphql-tag": "^2.12.6",
     "helmet": "^8.1.0",
     "inquirer": "^12.8.2",
     "ioredis": "^5.4.1",


### PR DESCRIPTION
## Summary
- use `graphql-tag` for the gql template literal
- include `graphql-tag` dependency

## Testing
- `npm test` *(fails: Can't find a root directory while resolving a config file path)*

------
https://chatgpt.com/codex/tasks/task_e_6887cb02e9a08333a273e1c6be0c976f