### PR TITLE
Refactor toast store interfaces

### DIFF
--- a/packages/ui/src/stores/toast.d.ts
+++ b/packages/ui/src/stores/toast.d.ts
@@ -1,13 +1,4 @@
-interface ToastState {
-  toasts: Array<{
-    id: string;
-    type: 'success' | 'error' | 'warning' | 'info';
-    title: string;
-    description?: string;
-  }>;
-  addToast: (toast: Omit<ToastState['toasts'][0], 'id'>) => void;
-  removeToast: (id: string) => void;
-}
+import type { ToastState } from './toast.types';
 export declare const useToastStore: import('zustand').UseBoundStore<Omit<import('zustand').StoreApi<ToastState>, 'setState'> & {
   setState<A extends string | { type: string }>(partial: ToastState | Partial<ToastState> | ((state: ToastState) => ToastState | Partial<ToastState>), replace?: boolean | undefined, action?: A | undefined): void;
 }>;

--- a/packages/ui/src/stores/toast.ts
+++ b/packages/ui/src/stores/toast.ts
@@ -1,16 +1,6 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-
-interface ToastState {
-  toasts: Array<{
-    id: string;
-    type: 'success' | 'error' | 'warning' | 'info';
-    title: string;
-    description?: string;
-  }>;
-  addToast: (toast: Omit<ToastState['toasts'][0], 'id'>) => void;
-  removeToast: (id: string) => void;
-}
+import type { ToastState } from './toast.types';
 
 export const useToastStore = create<ToastState>()(
   devtools(

--- a/packages/ui/src/stores/toast.types.ts
+++ b/packages/ui/src/stores/toast.types.ts
@@ -1,0 +1,12 @@
+export interface Toast {
+  id: string;
+  type: 'success' | 'error' | 'warning' | 'info';
+  title: string;
+  description?: string;
+}
+
+export interface ToastState {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, 'id'>) => void;
+  removeToast: (id: string) => void;
+}


### PR DESCRIPTION
## Summary
- centralize toast store interface declarations
- update store and `.d.ts` file to reference shared interfaces

## Testing
- `npm test`
- `npx tsc --noEmit -p packages/ui/tsconfig.json` *(fails: cannot find module 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_688c1eb472c48333a31533e2cce6ff95