### PR TITLE
feat: add Microsoft 365 integration connector

### DIFF
--- a/apps/api/routes/integrations.js
+++ b/apps/api/routes/integrations.js
@@ -4,6 +4,7 @@ import { logger } from '../logger.js';
 import { deleteConfigByKey, fetchConfigByKey } from '../utils/dbUtils.js';
 
 const router = express.Router();
+router.use(express.json());
 
 async function getIntegrationLayer() {
   try {
@@ -75,26 +76,62 @@ router.get('/', (req, res) => {
       const integrations = [
         {
           id: 4,
+          type: 'slack',
           name: 'Slack',
           description: 'Slack integration for Nova Universe',
           status: 'active',
         },
         {
           id: 5,
+          type: 'teams',
           name: 'Microsoft Teams',
           description: 'Teams integration for Nova Universe',
           status: 'planned',
         },
         {
           id: 6,
+          type: 'discord',
           name: 'Discord',
           description: 'Discord integration for Nova Universe',
           status: 'beta',
         },
+        {
+          id: 7,
+          type: 'microsoft365',
+          name: 'Microsoft 365',
+          description: 'Microsoft 365 calendar and email integration',
+          status: 'planned',
+        },
       ];
-      res.json({ integrations, storedConfigs });
+      const integrationsWithConfig = integrations.map((i) => ({
+        ...i,
+        config: storedConfigs[i.type] || {},
+      }));
+      res.json({ integrations: integrationsWithConfig });
     },
   );
+});
+
+/**
+ * Save integration configuration
+ */
+router.post('/:key', (req, res) => {
+  const { key } = req.params;
+  const config = req.body;
+  if (!config || typeof config !== 'object') {
+    return res.status(400).json({ error: 'Invalid request body', errorCode: 'INVALID_BODY' });
+  }
+
+  const dbKey = `integration_${key}`;
+  const query =
+    'INSERT INTO config (key, value) VALUES ($1, $2) ON CONFLICT(key) DO UPDATE SET value = excluded.value';
+  db.run(query, [dbKey, JSON.stringify(config)], (err) => {
+    if (err) {
+      logger.error(`Failed to save integration config for ${key}: ${err.message}`);
+      return res.status(500).json({ error: 'Database error', errorCode: 'DB_ERROR' });
+    }
+    res.json({ message: 'Integration configuration saved' });
+  });
 });
 
 /**

--- a/apps/unified/src/pages/admin/IntegrationsPage.tsx
+++ b/apps/unified/src/pages/admin/IntegrationsPage.tsx
@@ -17,23 +17,6 @@ const PlusIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-const CogIcon = ({ className }: { className?: string }) => (
-  <svg
-    className={className}
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.240.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
-    />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-  </svg>
-);
-
 const CheckCircleIcon = ({ className }: { className?: string }) => (
   <svg
     className={className}
@@ -148,7 +131,7 @@ const PlayIcon = ({ className }: { className?: string }) => (
 
 // Integration interface
 interface Integration {
-  id: string;
+  id: number;
   name: string;
   type: string;
   status: 'connected' | 'disconnected' | 'error' | 'testing';
@@ -168,6 +151,7 @@ const INTEGRATION_TYPES = [
   { value: 'smtp', label: 'SMTP Email', category: 'Communication' },
   { value: 'slack', label: 'Slack', category: 'Communication' },
   { value: 'teams', label: 'Microsoft Teams', category: 'Communication' },
+  { value: 'microsoft365', label: 'Microsoft 365', category: 'Communication' },
   { value: 'webhook', label: 'Generic Webhook', category: 'API' },
   { value: 'jira', label: 'Jira', category: 'Project Management' },
   { value: 'servicenow', label: 'ServiceNow', category: 'ITSM' },
@@ -183,10 +167,36 @@ export default function IntegrationsPage() {
   const [testingIntegration, setTestingIntegration] = useState<string | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string>('');
   const [statusFilter, setStatusFilter] = useState<string>('');
+  const [formData, setFormData] = useState({
+    name: '',
+    type: 'microsoft365',
+    config: { tenantId: '', clientId: '', clientSecret: '', mailbox: '' },
+  });
 
   useEffect(() => {
     loadIntegrations();
   }, []);
+
+  useEffect(() => {
+    if (editingIntegration) {
+      setFormData({
+        name: editingIntegration.name,
+        type: editingIntegration.type,
+        config: {
+          tenantId: editingIntegration.config?.tenantId || '',
+          clientId: editingIntegration.config?.clientId || '',
+          clientSecret: editingIntegration.config?.clientSecret || '',
+          mailbox: editingIntegration.config?.mailbox || '',
+        },
+      });
+    } else if (showCreateModal) {
+      setFormData({
+        name: '',
+        type: 'microsoft365',
+        config: { tenantId: '', clientId: '', clientSecret: '', mailbox: '' },
+      });
+    }
+  }, [editingIntegration, showCreateModal]);
 
   const loadIntegrations = async () => {
     try {
@@ -202,11 +212,34 @@ export default function IntegrationsPage() {
         setIntegrations([]);
       }
     } catch (_error) {
-      console.warn('Integrations API unavailable, using fallback data:', error);
+      console.warn('Integrations API unavailable, using fallback data:', _error);
       // Fallback to empty state
       setIntegrations([]);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const saveIntegration = async () => {
+    try {
+      const response = await apiFetch(`/api/integrations/${formData.type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData.config),
+      });
+      if (response.ok) {
+        toast.success(
+          editingIntegration ? 'Integration updated successfully' : 'Integration created successfully',
+        );
+        setShowCreateModal(false);
+        setEditingIntegration(null);
+        await loadIntegrations();
+      } else {
+        toast.error('Failed to save integration');
+      }
+    } catch (_error) {
+      console.error('Error saving integration:', _error);
+      toast.error('Failed to save integration');
     }
   };
 
@@ -227,7 +260,7 @@ export default function IntegrationsPage() {
 
       toast.success('Integration test successful');
     } catch (_error) {
-      console.error('Error testing integration:', error);
+      console.error('Error testing integration:', _error);
       toast.error('Integration test failed');
     } finally {
       setTestingIntegration(null);
@@ -246,7 +279,7 @@ export default function IntegrationsPage() {
 
       toast.success(`Integration ${enabled ? 'enabled' : 'disabled'} successfully`);
     } catch (_error) {
-      console.error('Error updating integration:', error);
+      console.error('Error updating integration:', _error);
       toast.error('Failed to update integration');
     }
   };
@@ -260,7 +293,7 @@ export default function IntegrationsPage() {
       setIntegrations(integrations.filter((integration) => integration.id !== integrationId));
       toast.success('Integration deleted successfully');
     } catch (_error) {
-      console.error('Error deleting integration:', error);
+      console.error('Error deleting integration:', _error);
       toast.error('Failed to delete integration');
     }
   };
@@ -634,11 +667,110 @@ export default function IntegrationsPage() {
                   </button>
                 </div>
 
-                <div className="py-8 text-center">
-                  <CogIcon className="mx-auto h-12 w-12 text-gray-400" />
-                  <p className="mt-4 text-gray-600 dark:text-gray-400">
-                    Integration configuration form will be implemented here
-                  </p>
+                <div className="space-y-4">
+                  <div>
+                    <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Name
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.name}
+                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                      className="input"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Type
+                    </label>
+                    <select
+                      value={formData.type}
+                      onChange={(e) =>
+                        setFormData({ ...formData, type: e.target.value })
+                      }
+                      className="input"
+                      disabled={!!editingIntegration}
+                    >
+                      {INTEGRATION_TYPES.map((type) => (
+                        <option key={type.value} value={type.value}>
+                          {type.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {formData.type === 'microsoft365' && (
+                    <div className="space-y-4">
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Tenant ID
+                        </label>
+                        <input
+                          type="text"
+                          value={formData.config.tenantId}
+                          onChange={(e) =>
+                            setFormData({
+                              ...formData,
+                              config: { ...formData.config, tenantId: e.target.value },
+                            })
+                          }
+                          className="input"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Client ID
+                        </label>
+                        <input
+                          type="text"
+                          value={formData.config.clientId}
+                          onChange={(e) =>
+                            setFormData({
+                              ...formData,
+                              config: { ...formData.config, clientId: e.target.value },
+                            })
+                          }
+                          className="input"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Client Secret
+                        </label>
+                        <input
+                          type="password"
+                          value={formData.config.clientSecret}
+                          onChange={(e) =>
+                            setFormData({
+                              ...formData,
+                              config: { ...formData.config, clientSecret: e.target.value },
+                            })
+                          }
+                          className="input"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Mailbox
+                        </label>
+                        <input
+                          type="email"
+                          value={formData.config.mailbox}
+                          onChange={(e) =>
+                            setFormData({
+                              ...formData,
+                              config: { ...formData.config, mailbox: e.target.value },
+                            })
+                          }
+                          className="input"
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
 
                 <div className="mt-8 flex justify-end space-x-3 border-t border-gray-200 pt-6 dark:border-gray-700">
@@ -651,19 +783,7 @@ export default function IntegrationsPage() {
                   >
                     Cancel
                   </button>
-                  <button
-                    onClick={() => {
-                      // Handle save
-                      toast.success(
-                        editingIntegration
-                          ? 'Integration updated successfully'
-                          : 'Integration created successfully',
-                      );
-                      setShowCreateModal(false);
-                      setEditingIntegration(null);
-                    }}
-                    className="btn btn-primary"
-                  >
+                  <button onClick={saveIntegration} className="btn btn-primary">
                     {editingIntegration ? 'Update' : 'Create'}
                   </button>
                 </div>

--- a/apps/unified/src/pages/admin/IntegrationsPage.tsx
+++ b/apps/unified/src/pages/admin/IntegrationsPage.tsx
@@ -164,7 +164,7 @@ export default function IntegrationsPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingIntegration, setEditingIntegration] = useState<Integration | null>(null);
-  const [testingIntegration, setTestingIntegration] = useState<string | null>(null);
+  const [testingIntegration, setTestingIntegration] = useState<number | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string>('');
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [formData, setFormData] = useState({
@@ -203,7 +203,7 @@ export default function IntegrationsPage() {
       setIsLoading(true);
 
       // Fetch integrations from API
-      const response = await apiFetch('/api/integrations');
+      const response = await apiFetch('/api/v1/integrations');
       if (response.ok) {
         const data = await response.json();
         setIntegrations(data.integrations || []);
@@ -222,7 +222,7 @@ export default function IntegrationsPage() {
 
   const saveIntegration = async () => {
     try {
-      const response = await apiFetch(`/api/integrations/${formData.type}`, {
+      const response = await apiFetch(`/api/v1/integrations/${formData.type}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData.config),
@@ -243,7 +243,7 @@ export default function IntegrationsPage() {
     }
   };
 
-  const testIntegration = async (integrationId: string) => {
+  const testIntegration = async (integrationId: number) => {
     try {
       setTestingIntegration(integrationId);
 
@@ -267,7 +267,7 @@ export default function IntegrationsPage() {
     }
   };
 
-  const toggleIntegration = async (integrationId: string, enabled: boolean) => {
+  const toggleIntegration = async (integrationId: number, enabled: boolean) => {
     try {
       setIntegrations(
         integrations.map((integration) =>
@@ -284,7 +284,7 @@ export default function IntegrationsPage() {
     }
   };
 
-  const deleteIntegration = async (integrationId: string) => {
+  const deleteIntegration = async (integrationId: number) => {
     if (!confirm('Are you sure you want to delete this integration?')) {
       return;
     }

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -46,6 +46,7 @@ packages/integrations/
 
 - **Slack Connector**: Team communication and workflow integration
 - **Zoom Connector**: Meeting management and user provisioning
+- **Microsoft 365 Connector**: Room calendar synchronization and email send/receive via Microsoft Graph
 
 ### AI & Automation
 
@@ -120,6 +121,10 @@ OKTA_TOKEN=your-api-token
 
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_USER_TOKEN=xoxp-your-user-token
+
+M365_TENANT_ID=00000000-0000-0000-0000-000000000000
+M365_CLIENT_ID=11111111-1111-1111-1111-111111111111
+M365_CLIENT_SECRET=super-secret-value
 
 CROWDSTRIKE_CLIENT_ID=your-client-id
 CROWDSTRIKE_CLIENT_SECRET=your-client-secret

--- a/packages/integrations/integration/connectors/microsoft365-connector.js
+++ b/packages/integrations/integration/connectors/microsoft365-connector.js
@@ -1,0 +1,151 @@
+/**
+ * Microsoft 365 Connector
+ * Provides room calendar synchronization and email send/receive via Microsoft Graph API
+ *
+ * @author Nova Team
+ * @version 1.0.0
+ */
+
+import { IConnector, ConnectorType, HealthStatus } from '../nova-integration-layer.js';
+import axios from 'axios';
+
+/**
+ * Microsoft 365 connector implementing OAuth 2.0 client credentials and Microsoft Graph API
+ */
+export class Microsoft365Connector extends IConnector {
+  constructor() {
+    super('microsoft365-connector', 'Microsoft 365', '1.0.0', ConnectorType.COLLABORATION);
+    this.config = null;
+    this.token = null;
+    this.tokenExpiresAt = 0;
+    this.client = axios.create({
+      baseURL: 'https://graph.microsoft.com/v1.0',
+      timeout: 30000,
+    });
+  }
+
+  /**
+   * Initialize connector with enterprise configuration
+   * @param {object} config - { tenantId, clientId, clientSecret }
+   */
+  async initialize(config) {
+    try {
+      this.config = config;
+      this.validateConfig(config);
+      await this.refreshAccessToken();
+      await this.health();
+      console.log('Microsoft 365 connector initialized successfully');
+    } catch (error) {
+      console.error('Failed to initialize Microsoft 365 connector:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Validate configuration
+   */
+  validateConfig(config) {
+    if (!config?.tenantId || !config?.clientId || !config?.clientSecret) {
+      throw new Error('Missing required Microsoft 365 configuration');
+    }
+  }
+
+  /**
+   * Refresh OAuth token using client credentials
+   */
+  async refreshAccessToken() {
+    const tokenUrl = `https://login.microsoftonline.com/${this.config.tenantId}/oauth2/v2.0/token`;
+    const params = new URLSearchParams();
+    params.append('client_id', this.config.clientId);
+    params.append('client_secret', this.config.clientSecret);
+    params.append('scope', 'https://graph.microsoft.com/.default');
+    params.append('grant_type', 'client_credentials');
+
+    const response = await axios.post(tokenUrl, params.toString(), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    this.token = response.data.access_token;
+    this.tokenExpiresAt = Date.now() + (response.data.expires_in - 60) * 1000;
+    this.client.defaults.headers.common.Authorization = `Bearer ${this.token}`;
+  }
+
+  /**
+   * Ensure a valid access token exists
+   */
+  async ensureToken() {
+    if (!this.token || Date.now() >= this.tokenExpiresAt) {
+      await this.refreshAccessToken();
+    }
+  }
+
+  /**
+   * Health check against Microsoft Graph
+   */
+  async health() {
+    try {
+      await this.ensureToken();
+      const response = await this.client.get('/organization?$top=1');
+      const status = response.status === 200 ? HealthStatus.HEALTHY : HealthStatus.DEGRADED;
+      return { status, lastCheck: new Date() };
+    } catch (error) {
+      return { status: HealthStatus.UNHEALTHY, lastCheck: new Date(), message: error.message };
+    }
+  }
+
+  /**
+   * List events for a room mailbox
+   * @param {string} roomEmail - Room mailbox address
+   * @param {Date} start - Start time
+   * @param {Date} end - End time
+   */
+  async listRoomEvents(roomEmail, start, end) {
+    await this.ensureToken();
+    const params = {
+      startDateTime: start.toISOString(),
+      endDateTime: end.toISOString(),
+    };
+    const response = await this.client.get(`/users/${encodeURIComponent(roomEmail)}/calendarView`, { params });
+    return response.data.value || [];
+  }
+
+  /**
+   * Create an event in a room mailbox
+   * @param {string} roomEmail
+   * @param {object} event
+   */
+  async createRoomEvent(roomEmail, event) {
+    await this.ensureToken();
+    const response = await this.client.post(`/users/${encodeURIComponent(roomEmail)}/events`, event);
+    return response.data;
+  }
+
+  /**
+   * Retrieve messages for a mailbox. Supports delta queries.
+   * @param {string} mailbox - mailbox email
+   * @param {string} [deltaLink] - optional deltaLink for incremental sync
+   */
+  async listMessages(mailbox, deltaLink) {
+    await this.ensureToken();
+    const url = deltaLink || `/users/${encodeURIComponent(mailbox)}/messages`;
+    const response = await this.client.get(url);
+    return response.data;
+  }
+
+  /**
+   * Send email from specified mailbox
+   * @param {string} mailbox - mailbox email
+   * @param {object} message - Graph message object
+   */
+  async sendMail(mailbox, message) {
+    await this.ensureToken();
+    await this.client.post(`/users/${encodeURIComponent(mailbox)}/sendMail`, {
+      message,
+      saveToSentItems: true,
+    });
+    return { success: true };
+  }
+}
+
+export default Microsoft365Connector;
+

--- a/test/microsoft365-admin-ui.test.js
+++ b/test/microsoft365-admin-ui.test.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import test from 'node:test';
+import assert from 'node:assert';
+
+const uiPath = 'apps/unified/src/pages/admin/IntegrationsPage.tsx';
+const apiPath = 'apps/api/routes/integrations.js';
+
+test('Admin UI includes Microsoft 365 integration form', () => {
+  const content = fs.readFileSync(uiPath, 'utf8');
+  assert.ok(content.includes('Microsoft 365'), 'Microsoft 365 entry missing');
+  assert.ok(content.includes('Tenant ID'), 'Tenant ID field missing');
+  assert.ok(content.includes('Client ID'), 'Client ID field missing');
+  assert.ok(content.includes('Client Secret'), 'Client Secret field missing');
+  assert.ok(content.includes('Mailbox'), 'Mailbox field missing');
+});
+
+test('Integrations API exposes Microsoft 365 config', () => {
+  const content = fs.readFileSync(apiPath, 'utf8');
+  assert.ok(content.includes('Microsoft 365'), 'Microsoft 365 not listed in API');
+  assert.ok(content.includes('integration_'), 'Database key prefix missing');
+  assert.ok(content.includes("router.post('/:key'"), 'POST route for integration config missing');
+});

--- a/test/microsoft365-connector.test.js
+++ b/test/microsoft365-connector.test.js
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import axios from 'axios';
+import Microsoft365Connector from '../packages/integrations/integration/connectors/microsoft365-connector.js';
+
+const createHttpClient = () => ({
+  defaults: { headers: { common: {} } },
+  get: async () => {},
+  post: async () => {},
+});
+
+const config = {
+  tenantId: '00000000-0000-0000-0000-000000000000',
+  clientId: '11111111-1111-1111-1111-111111111111',
+  clientSecret: 'example-secret',
+};
+
+test('Microsoft365Connector initializes and acquires token', async () => {
+  const httpClient = createHttpClient();
+  axios.create = () => httpClient;
+  let tokenRequested = false;
+  axios.post = async () => {
+    tokenRequested = true;
+    return { data: { access_token: 'test-token', expires_in: 3600 } };
+  };
+
+  const connector = new Microsoft365Connector();
+  await connector.initialize(config);
+
+  assert.equal(tokenRequested, true);
+  assert.equal(connector.token, 'test-token');
+  assert.equal(httpClient.defaults.headers.common.Authorization, 'Bearer test-token');
+});
+
+test('Microsoft365Connector sendMail posts to Graph API', async () => {
+  const httpClient = createHttpClient();
+  let postedUrl = '';
+  let postedBody;
+  httpClient.post = async (url, body) => {
+    postedUrl = url;
+    postedBody = body;
+  };
+  axios.create = () => httpClient;
+  axios.post = async () => ({ data: { access_token: 'test-token', expires_in: 3600 } });
+
+  const connector = new Microsoft365Connector();
+  await connector.initialize(config);
+
+  await connector.sendMail('user@example.com', {
+    subject: 'Hello',
+    body: { contentType: 'Text', content: 'Hi' },
+    toRecipients: [{ emailAddress: { address: 'a@example.com' } }],
+  });
+
+  assert.equal(postedUrl, '/users/user%40example.com/sendMail');
+  assert.equal(postedBody.saveToSentItems, true);
+  assert.ok(postedBody.message);
+});
+


### PR DESCRIPTION
## Summary
- add Microsoft 365 connector for calendar sync and email send/receive via Microsoft Graph
- expose Microsoft 365 integration in admin UI with form-driven configuration
- store Microsoft 365 configuration in database via new integrations API endpoint

## Testing
- `node --test test/microsoft365-connector.test.js test/microsoft365-admin-ui.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0b6bcf2a48333bb23c676fb1d2066